### PR TITLE
Form key in res map

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,8 @@
 (defproject replumb "0.1.0-SNAPSHOT"
+  :description "ClojureScript plumbing for your bootstrapped REPLs."
+  :url "https://github.com/clojurex/replumb"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/clojurescript "1.7.145"]
                  [cljsjs/jqconsole "2.12.0-0"]

--- a/src/cljs/replumb/core.cljs
+++ b/src/cljs/replumb/core.cljs
@@ -24,20 +24,17 @@
   ```
 
   It initializes the repl harness if necessary."
-  {:added "0.1.0"}
   ([callback source] (repl/read-eval-call {} callback source))
   ([opts callback source] (repl/read-eval-call opts callback source)))
 
 (defn ^:export get-prompt
   "Retrieves the repl prompt to display, according to the current
   namespace. Returns a string."
-  {:added "0.1.0"}
   []
   (str (repl/current-ns) "=> "))
 
 (defn ^:export error->str
   "Return the message string of the input `js/Error`."
-  {:added "0.1.0"}
   ([error] (common/extract-message error))
   ([error print-stack?] (common/extract-message error print-stack?)))
 
@@ -46,7 +43,6 @@
 
   It returns the content of `:value` in case of success and the content
   of `:error` (a `js/Error`) in case of failure."
-  {:added "0.1.0"}
   [result-map]
   (if (:success? result-map)
     (:value result-map)
@@ -55,12 +51,10 @@
 (defn ^:export success?
   "Given a `result-map`, tells whether the evaluation was successful."
   [result-map]
-  {:added "0.1.0"}
   (:success? result-map))
 
 (defn ^:export result->string
   "Given a `result-map`, returns the result of an evaluation as string."
-  {:added "0.1.0"}
   ([result-map]
    (result->string result-map false))
   ([result-map print-stack?]

--- a/src/cljs/replumb/repl.cljs
+++ b/src/cljs/replumb/repl.cljs
@@ -220,14 +220,12 @@
 (defn validated-call-back!
   [call-back! res]
   {:pre [(map? res)
-         (or (find res :error) (find res :value))]
-   :post [(map? %)
-          (find % :form)
-          (or (find % :error) (find % :value))
-          (or (and (find % :value) (get % :success?))
-              (and (find % :error) (not (get % :success?))))
-          (or (and (find % :value) (string? (get % :value)))
-              (and (find % :error) (instance? js/Error (get % :error))))]}
+         (find res :form)
+         (or (find res :error) (find res :value))
+         (or (and (find res :value) (get res :success?))
+             (and (find res :error) (not (get res :success?))))
+         (or (and (find res :value) (string? (get res :value)))
+             (and (find res :error) (instance? js/Error (get res :error))))]}
   (call-back! res))
 
 (defn call-side-effect!
@@ -242,8 +240,8 @@
 
 (defn warning-error-map!
   "Checks if there has been a warning and if so will return the correct
-  error map instead of the input one. Notice that if the input map was
-  already an error map, the warning will be ignored."
+  error map instead of the input one. Note that if the input map was
+  already an :error, the warning will be ignored."
   [opts {:keys [value error] :as original-res}]
   (if error
     original-res

--- a/src/cljs/replumb/repl.cljs
+++ b/src/cljs/replumb/repl.cljs
@@ -12,10 +12,10 @@
             [replumb.doc-maps :as docs]
             [replumb.common :as common]))
 
-(def ^:dynamic  *custom-eval-fn* "See cljs.js/*eval-fn* in ClojureScript core."
+(def ^:dynamic  *replumb-eval-fn* "See cljs.js/*eval-fn* in ClojureScript core."
   cljs/js-eval)
 
-(def ^:dynamic *custom-load-fn* "See cljs.js/*load-fn* in ClojureScript core."
+(def ^:dynamic *replumb-load-fn* "See cljs.js/*load-fn* in ClojureScript core."
   load/js-load)
 
 ;;;;;;;;;;;;;
@@ -125,8 +125,8 @@
   ([]
    (env-opts! {:ns      (:current-ns @app-env)
                :context :expr
-               :load    *custom-load-fn*
-               :eval    *custom-eval-fn*}))
+               :load    *replumb-load-fn*
+               :eval    *replumb-eval-fn*}))
   ([& maps]
    (apply merge (make-base-eval-opts!) maps)))
 
@@ -177,29 +177,28 @@
                     ~@(-> specs canonicalize-specs process-reloads!)))
       {:merge true :line 1 :column 1})))
 
-;;;;;;;;;;;;;;;;;;;;;;;;;
-;;; Eval handling fns ;;;
-;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Callback handling fns ;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-(defn forward-success!
-  "Handles the case when the evaluation returned success.
-  Supports the following options (opts = option map):
+(defn success-map
+  "Builds the map to return when the evaluation returned success.
+  Supports the following options:
 
   * :no-pr-str-on-value avoids wrapping value in pr-str."
-  ([opts cb value]
-   (cb {:success? true
-        :value (if-not (:no-pr-str-on-value opts)
-                 (pr-str value)
-                 value)})))
+  ([opts form value]
+   {:success? true
+    :form form
+    :value (if-not (:no-pr-str-on-value opts)
+             (pr-str value)
+             value)}))
 
-(defn forward-error!
-  "Handles the case when the evaluation returned error.
-  Always pushes a js/Error to the callback."
-  ([opts cb error]
-   {:pre [(instance? js/Error error)]}
-   (set! *e error)
-   (cb {:success? false
-        :error error})))
+(defn error-map
+  "Builds the map to return when the evaluation returned error."
+  ([opts form error]
+   {:success? false
+    :form form
+    :error error}))
 
 (defn reset-last-warning!
   []
@@ -218,17 +217,58 @@
     (when-let [s (ana/error-message warning-type extra)]
       (swap! app-env assoc :last-eval-warning (ana/message env s)))))
 
-(defn handle-eval-result!
+(defn validated-call-back!
+  [call-back! res]
+  {:pre [(map? res)
+         (or (find res :error) (find res :value))]
+   :post [(map? %)
+          (find % :form)
+          (or (find % :error) (find % :value))
+          (or (and (find % :value) (get % :success?))
+              (and (find % :error) (not (get % :success?))))
+          (or (and (find % :value) (string? (get % :value)))
+              (and (find % :error) (instance? js/Error (get % :error))))]}
+  (call-back! res))
+
+(defn call-side-effect!
+  "Execute the correct side effecting function from data.
+  Handles :side-effect!, :on-error! and on-success!."
+  [data {:keys [value error]}]
+  (if-let [f! (:side-effect! data)]
+    (f!)
+    (if-not error
+      (when-let [s! (:on-success! data)] (s!))
+      (when-let [e! (:on-error! data)] (e!)))))
+
+(defn warning-error-map!
+  "Checks if there has been a warning and if so will return the correct
+  error map instead of the input one. Notice that if the input map was
+  already an error map, the warning will be ignored."
+  [opts {:keys [value error] :as original-res}]
+  (if error
+    original-res
+    (if-let [warning-msg (:last-eval-warning @app-env)]
+      (let [warning-error (ex-info warning-msg ex-info-data)]
+        (when (:verbose opts)
+          (debug-prn "Erroring on last warning: " warning-msg))
+        (common/wrap-error warning-error))
+      original-res)))
+
+(defn call-back!
   "Handles the evaluation result, calling the callback in the right way,
-  based on the success or error of the evaluation and executing
-  (side-effect!) *before* the callback is called. It expects the same
-  map as ClojureScript's cljs.js callback, that is :value if success
-  and :error if not.
+  based on the success or error of the evaluation. The res parameter
+  expects the same map as ClojureScript's cljs.js callback,
+  :value if success and :error if not. The data parameter might contain
+  additional stuff:
 
-  ** Every function in this namespace should call handle-eval-result! as
-  single point of exit and therefore respect its contract. **
+  * :form the source form that has been eval-ed
+  * :on-success! 0-arity function that will be executed on success
+  * :on-error! 0-arity function that will be executed on error
+  * :side-effect! 0-arity function that if present will be executed for
+    both success and error, effectively disabling the individual
+    on-success!  and on-error!
 
-  It supports the following opts (map):
+  Call-back! also supports the following opts:
 
   * :verbose will enable the the evaluation logging, defaults to false.
   * :no-pr-str-on-value avoids wrapping successful value in a pr-str
@@ -237,37 +277,36 @@
 
   1. The opts map passed here overrides the environment options.
   2. This function will also clear the :last-eval-warning flag in
-     app-env.
-  3. There is also an arity for differentiating the side effect based on
-     success or error."
+  app-env.
+  3. It will execute (:side-effect!) or (on-success!)  and (on-error!)
+  *before* the callback is called.
+
+  ** Every function in this namespace should call call-back! as
+  single point of exit. **"
   ([opts cb res]
-   (handle-eval-result! opts cb identity res))
-  ([opts cb side-effect! {:keys [value error] :as res}]
-   (handle-eval-result! opts cb side-effect! side-effect! res))
-  ([opts cb on-success! on-error! res]
-   {:pre [(map? res) (or (find res :error) (find res :value))]}
+   (call-back! opts cb {} res))
+  ([opts cb data res]
    (when (:verbose opts)
-     (debug-prn "Handling result:\n" (with-out-str (pprint res))))
-   (if-let [warning-msg (:last-eval-warning @app-env)]
-     (do (when (:verbose opts)
-           (debug-prn "Last warning message: " warning-msg))
-         (on-error!)
-         (reset-last-warning!)
-         (forward-error! opts cb (ex-info warning-msg ex-info-data)))
-     (let [{:keys [value error]} res]
+     (debug-prn "Calling back!\n" (with-out-str (pprint {:opts opts :data data :res res}))))
+   (let [new-map (warning-error-map! opts res)]
+     (let [{:keys [value error]} new-map]
+       (call-side-effect! data new-map)
+       (reset-last-warning!)
        (if-not error
-         (do (on-success!) (reset-last-warning!) (forward-success! opts cb value))
-         (do (on-error!) (reset-last-warning!) (forward-error! opts cb error)))))))
+         (do (set! *e nil)
+             (cb (success-map opts (:form data) value)))
+         (do (set! *e error)
+             (cb (error-map opts (:form data) error))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Processing fns - from mfikes/plank ;;;
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (defn process-require
-  [opts cb kind specs]
+  [opts cb data kind specs]
   ;; TODO - cannot find a way to handle (require something) correctly, note no quote
   (if-not (= 'quote (ffirst specs))
-    (handle-eval-result! opts cb (common/error-argument-must-be-symbol "require" ex-info-data))
+    (call-back! opts cb data (common/error-argument-must-be-symbol "require" ex-info-data))
     (let [is-self-require? (and (= :kind :require) (self-require? specs))
           [target-ns restore-ns] (if-not is-self-require?
                                    [(:current-ns @app-env) nil]
@@ -279,28 +318,26 @@
                  ns-form
                  (make-base-eval-opts! opts)
                  (fn [error]
-                   (when (:verbose opts)
-                     (debug-prn "Callback in process-require received: " error))
-                   (handle-eval-result! opts cb
-                                        #(when is-self-require?
-                                           (swap! app-env assoc :current-ns restore-ns))
-                                        (if error
-                                          error
-                                          (common/wrap-success nil))))))))
+                   (call-back! opts cb
+                               (merge data
+                                      {:side-effect! #(when is-self-require?
+                                                        (swap! app-env assoc :current-ns restore-ns))})
+                               (if error
+                                 error
+                                 (common/wrap-success nil))))))))
 
 (defn process-doc
-  [cb env sym]
-  (handle-eval-result! {:no-pr-str-on-value true}
-                       cb
-                       (common/wrap-success
-                        (with-out-str
-                          (cond
-                            (docs/special-doc-map sym) (repl/print-doc (docs/special-doc sym))
-                            (docs/repl-special-doc-map sym) (repl/print-doc (docs/repl-special-doc sym))
-                            :else (repl/print-doc (get-var env sym)))))))
+  [opts cb data env sym]
+  (call-back! {:no-pr-str-on-value true} cb data
+              (common/wrap-success
+               (with-out-str
+                 (cond
+                   (docs/special-doc-map sym) (repl/print-doc (docs/special-doc sym))
+                   (docs/repl-special-doc-map sym) (repl/print-doc (docs/repl-special-doc sym))
+                   :else (repl/print-doc (get-var env sym)))))))
 
 (defn process-pst
-  [opts cb expr]
+  [opts cb data expr]
   (if-let [expr (or expr '*e)]
     (cljs/eval st
                expr
@@ -309,59 +346,57 @@
                  (let [[opts msg] (if res
                                     [(assoc opts :no-pr-str-on-value true) (common/extract-message res true true)]
                                     [opts res])]
-                   (handle-eval-result! opts cb (common/wrap-success msg)))))
-    (handle-eval-result! opts cb (common/wrap-success nil))))
+                   (call-back! opts cb data (common/wrap-success msg)))))
+    (call-back! opts cb data (common/wrap-success nil))))
 
 (defn process-in-ns
-  [opts cb ns-string]
+  [opts cb data ns-string]
   (cljs/eval
    st
    ns-string
    (make-base-eval-opts! opts)
    (fn [result]
      (if (and (map? result) (:error result))
-       (handle-eval-result! opts cb result)
+       (call-back! opts cb data result)
        (let [ns-symbol result]
          (when (:verbose opts)
            (debug-prn "in-ns argument is symbol? " (symbol? ns-symbol)))
          (if-not (symbol? ns-symbol)
-           (handle-eval-result! opts cb
-                                (common/error-argument-must-be-symbol "in-ns" ex-info-data))
+           (call-back! opts cb data (common/error-argument-must-be-symbol "in-ns" ex-info-data))
            (if (some (partial = ns-symbol) (known-namespaces))
-             (handle-eval-result! opts cb
-                                  #(swap! app-env assoc :current-ns ns-symbol)
-                                  (common/wrap-success nil))
+             (call-back! opts cb
+                         (merge data {:side-effect! #(swap! app-env assoc :current-ns ns-symbol)})
+                         (common/wrap-success nil))
              (let [ns-form `(~'ns ~ns-symbol)]
                (cljs/eval
                 st
                 ns-form
                 (make-base-eval-opts! opts)
                 (fn [error]
-                  (handle-eval-result! opts
-                                       cb
-                                       #(swap! app-env assoc :current-ns ns-symbol)
-                                       identity
-                                       (if error
-                                         (common/wrap-error error)
-                                         (common/wrap-success nil)))))))))))))
+                  (call-back! opts
+                              cb
+                              (merge data {:on-success! #(swap! app-env assoc :current-ns ns-symbol)})
+                              (if error
+                                (common/wrap-error error)
+                                (common/wrap-success nil)))))))))))))
 
 (defn process-repl-special
-  [opts cb expression-form]
+  [opts cb data expression-form]
   (let [env (assoc (ana/empty-env) :context :expr
                    :ns {:name (:current-ns @app-env)})
         argument (second expression-form)]
     (case (first expression-form)
-      in-ns (process-in-ns opts cb argument)
-      require (process-require opts cb :require (rest expression-form))
-      require-macros (process-require opts cb :require-macros (rest expression-form))
-      import (process-require opts cb :import (rest expression-form))
-      doc (process-doc cb env argument)
-      source (handle-eval-result! opts cb (common/error-keyword-not-supported "source" ex-info-data))                 ;; (println (fetch-source (get-var env argument)))
-      pst (process-pst opts cb argument)
-      load-file (handle-eval-result! opts cb (common/error-keyword-not-supported "load-file" ex-info-data)))))        ;; (process-load-file argument opts)
+      in-ns (process-in-ns opts cb data argument)
+      require (process-require opts cb data :require (rest expression-form))
+      require-macros (process-require opts cb data :require-macros (rest expression-form))
+      import (process-require opts cb data :import (rest expression-form))
+      doc (process-doc opts cb data env argument)
+      source (call-back! opts cb data (common/error-keyword-not-supported "source" ex-info-data)) ;; (println (fetch-source (get-var env argument)))
+      pst (process-pst opts cb data argument)
+      load-file (call-back! opts cb data (common/error-keyword-not-supported "load-file" ex-info-data))))) ;; (process-load-file argument opts)
 
 (defn process-1-2-3
-  [expression-form value]
+  [data expression-form value]
   (when-not (or ('#{*1 *2 *3 *e} expression-form)
                 (ns-form? expression-form))
     (set! *3 *2)
@@ -375,6 +410,8 @@
 (defn init-repl!
   "The init-repl function."
   [opts]
+  (when (:verbose opts)
+    (debug-prn "Initializing REPL environment..." ))
   (assert (= cljs.analyzer/*cljs-ns* 'cljs.user))
   (set! *target* "default")
   (swap! app-env merge (valid-opts opts))
@@ -396,12 +433,8 @@
 (defn init-repl-if-necessary!
   [opts cb]
   (when (:needs-init? (swap! app-env update-to-initializing))
-    (try
-      (do (init-repl! opts)
-          (swap! app-env update-to-initialized))
-      (catch :default e
-        (handle-eval-result! opts cb (common/wrap-error (str "INIT - "
-                                                             (common/extract-message e))))))))
+    (do (init-repl! opts)
+        (swap! app-env update-to-initialized))))
 
 (defn read-eval-call
   "Reads, evaluates and calls back with the evaluation result.
@@ -424,15 +457,18 @@
 
   It initializes the repl harness if necessary."
   [opts cb source]
-  (init-repl-if-necessary! opts cb)
   (try
     (let [expression-form (repl-read-string source)
-          opts (valid-opts opts)]
+          opts (valid-opts opts)
+          data {:form expression-form}]
+      (init-repl-if-necessary! opts cb)
+      (when (:verbose opts)
+        (debug-prn "Evaluating: " source))
       (when (:verbose opts)
         (debug-prn "Evaluating " expression-form " with options " opts))
       (binding [ana/*cljs-warning-handlers* [(partial custom-warning-handler opts cb)]]
         (if (docs/repl-special? expression-form)
-          (process-repl-special opts cb expression-form)
+          (process-repl-special opts cb data expression-form)
           (cljs/eval-str st
                          source
                          source
@@ -441,19 +477,18 @@
                                 {:source-map false
                                  :def-emits-var true}
                                 opts)
-                         (fn [ret]
+                         (fn [res]
                            (when (:verbose opts)
-                             (debug-prn "Evaluation returned: " ret))
-                           (handle-eval-result! opts
-                                                cb
-                                                #(do (process-1-2-3 expression-form (:value ret))
-                                                     (swap! app-env assoc :current-ns (:ns ret)))
-                                                identity
-                                                ret))))))
+                             (debug-prn "Evaluation returned: " res))
+                           (call-back! opts cb
+                                       (merge data
+                                              {:on-success! #(do (process-1-2-3 data expression-form (:value res))
+                                                                 (swap! app-env assoc :current-ns (:ns res)))})
+                                       res))))))
     (catch :default e
       (when (:verbose opts)
         (debug-prn "Exception caught in read-eval-call: " e))
-      (handle-eval-result! opts cb (common/wrap-error e)))))
+      (call-back! opts cb {} (common/wrap-error e)))))
 
 (defn reset-env!
   "It dons the following (in order):

--- a/test/cljs/replumb/repl_test.cljs
+++ b/test/cljs/replumb/repl_test.cljs
@@ -5,6 +5,8 @@
             [replumb.common :as common :refer [echo-callback valid-eval-result?
                                                extract-message valid-eval-error?]]))
 
+(def validated-echo-cb (partial repl/validated-call-back! echo-callback))
+
 (deftest init
   ;; This test heavily relies on repl execution order. If the repl is already
   ;; initialized before this point this test will fail. It is a good idea not
@@ -12,7 +14,7 @@
   ;; order if this happens. At the moment it is disabled
   ;; (is (not (:initializing? @repl/app-env)) "Flag :initializing? should be false before init")
   ;; (is (:needs-init? @repl/app-env) "Flag :needs-init? should be true before init")
-  (let [res (repl/read-eval-call {} echo-callback "(def c 4)")]
+  (let [res (repl/read-eval-call {} validated-echo-cb "(def c 4)")]
     (is (success? res) "Init should return successfully")
     (is (not (:initializing? @repl/app-env)) "Flag :initializing? should be false when the init exits")
     (is (not (:needs-init? @repl/app-env)) "Flag :needs-init? should be false when the init exits")
@@ -22,21 +24,21 @@
   (is (symbol? (repl/current-ns)) "The current ns should be a symbol"))
 
 (deftest process-pst
-  (let [res (do (repl/read-eval-call {} echo-callback "(throw (ex-info \"This is my custom error message %#FT%\" {:tag :exception}))")
-                (repl/read-eval-call {} echo-callback "*e"))
+  (let [res (do (repl/read-eval-call {} validated-echo-cb "(throw (ex-info \"This is my custom error message %#FT%\" {:tag :exception}))")
+                (repl/read-eval-call {} validated-echo-cb "*e"))
         error (unwrap-result res)]
     (is (success? res) "Eval of *e with error should return successfully")
     (is (valid-eval-result? error) "Eval of *e with error should be a valid error")
     (is (re-find #"This is my custom error message %#FT%" error) "Eval of *e with error should return the correct message")
     (repl/reset-env!))
-  (let [res (do (repl/read-eval-call {} echo-callback "(throw (ex-info \"This is my custom error message %#FT%\" {:tag :exception}))")
-                (repl/read-eval-call {} echo-callback "(pst)"))
+  (let [res (do (repl/read-eval-call {} validated-echo-cb "(throw (ex-info \"This is my custom error message %#FT%\" {:tag :exception}))")
+                (repl/read-eval-call {} validated-echo-cb "(pst)"))
         trace (unwrap-result res)]
     (is (success? res) "(pst) with previous error should return successfully")
     (is (valid-eval-result? trace) "(pst) with previous error should be a valid result")
     (is (re-find #"This is my custom error message %#FT%" trace) "(pst) with previous error should return the correct message")
     (repl/reset-env!))
-  (let [res (repl/read-eval-call {} echo-callback "(pst)")
+  (let [res (repl/read-eval-call {} validated-echo-cb "(pst)")
         trace (unwrap-result res)]
     (is (success? res) "(pst) with no error should return successfully")
     (is (valid-eval-result? trace) "(pst) with no error should be a valid result")
@@ -44,12 +46,12 @@
     (repl/reset-env!)))
 
 (deftest process-doc
-  (let [res (repl/read-eval-call {} echo-callback "(doc 'println)")
+  (let [res (repl/read-eval-call {} validated-echo-cb "(doc 'println)")
         error (unwrap-result res)]
     (is (not (success? res)) "(doc 'symbol) should have correct error")
     (is (valid-eval-error? error) "(doc 'symbol) should result in an js/Error")
     (repl/reset-env!))
-  (let [res (repl/read-eval-call {} echo-callback "(doc println)")
+  (let [res (repl/read-eval-call {} validated-echo-cb "(doc println)")
         docstring (unwrap-result res)]
     (is (success? res) "(doc symbol) should succeed")
     (is (valid-eval-result? docstring) "(doc symbol) should be a valid result")
@@ -58,13 +60,13 @@
     (repl/reset-env!)))
 
 (deftest process-in-ns
-  (let [res (repl/read-eval-call {} echo-callback "(in-ns \"first.namespace\")")
+  (let [res (repl/read-eval-call {} validated-echo-cb "(in-ns \"first.namespace\")")
         error (unwrap-result res)]
     (is (not (success? res)) "(in-ns \"string\") should NOT succeed")
     (is (valid-eval-error? error) "(in-ns \"string\")  should result in an js/Error")
     (is (= "Argument to in-ns must be a symbol" (extract-message error)) "(in-ns \"string\") should have correct error")
     (repl/reset-env!))
-  (let [res (repl/read-eval-call {} echo-callback "(in-ns first.namespace)")
+  (let [res (repl/read-eval-call {} validated-echo-cb "(in-ns first.namespace)")
         error (unwrap-result res)]
     (is (not (success? res)) "(in-ns symbol) should NOT succeed")
     (is (valid-eval-error? error) "(in-ns symbol)  should result in an js/Error")
@@ -73,7 +75,7 @@
             (re-find #"Can't find variable" (extract-message error))
             (re-find #"Argument to in-ns must be a symbol" (extract-message error))) "(in-ns symbol) should have correct error")
     (repl/reset-env!))
-  (let [res (repl/read-eval-call {} echo-callback "(in-ns 'first.namespace)")
+  (let [res (repl/read-eval-call {} validated-echo-cb "(in-ns 'first.namespace)")
         out (unwrap-result res)]
     (is (success? res) "(in-ns 'symbol) should succeed")
     (is (valid-eval-result? out) "(in-ns 'symbol) should be a valid result")
@@ -82,23 +84,23 @@
 
   ;; Note that (do (in-ns 'my.namespace) (def a 3) (in-ns 'cljs) my.namespace/a)
   ;; Does not work in ClojureScript!
-  (let [res (do (repl/read-eval-call {} echo-callback "(in-ns 'first.namespace)")
-                (repl/read-eval-call {} echo-callback "(def a 3)")
-                (repl/read-eval-call {} echo-callback "(in-ns 'second.namespace)")
-                (repl/read-eval-call {} echo-callback "first.namespace/a"))
+  (let [res (do (repl/read-eval-call {} validated-echo-cb "(in-ns 'first.namespace)")
+                (repl/read-eval-call {} validated-echo-cb "(def a 3)")
+                (repl/read-eval-call {} validated-echo-cb "(in-ns 'second.namespace)")
+                (repl/read-eval-call {} validated-echo-cb "first.namespace/a"))
         out (unwrap-result res)]
     (is (success? res) "Defining variable in namespace and querying it should succeed")
     (is (= "3" out) "Defining variable in namespace and querying should intern persistent var")
     (repl/reset-env! ['first.namespace 'second.namespace])))
 
 (deftest process-ns
-  (let [res (repl/read-eval-call {} echo-callback "(ns 'first.namespace)")
+  (let [res (repl/read-eval-call {} validated-echo-cb "(ns 'first.namespace)")
         error (unwrap-result res)]
     (is (not (success? res)) "(ns 'something) should NOT succeed")
     (is (valid-eval-error? error) "(ns 'something) should result in an js/Error")
     (is (re-find #"Namespaces must be named by a symbol" (extract-message error)) "(ns 'something) should have correct error")
     (repl/reset-env!))
-  (let [res (repl/read-eval-call {} echo-callback "(ns my.namespace)")
+  (let [res (repl/read-eval-call {} validated-echo-cb "(ns my.namespace)")
         out (unwrap-result res)]
     (is (success? res) "(ns something) should succeed")
     (is (valid-eval-result? out) "(ns something) should be a valid result")
@@ -106,40 +108,40 @@
     (repl/reset-env! ['my.namespace])))
 
 (deftest process-require
-  (let [res (repl/read-eval-call {} echo-callback "(require something)")
+  (let [res (repl/read-eval-call {} validated-echo-cb "(require something)")
         error (unwrap-result res)]
     (is (not (success? res)) "(require something) should NOT succeed")
     (is (valid-eval-error? error) "(require something) should result in an js/Error")
     (is (re-find #"is not ISeqable" (extract-message error)) "(require something) should have correct error")
     (repl/reset-env!))
-  (let [res (repl/read-eval-call {} echo-callback "(require \"something\")")
+  (let [res (repl/read-eval-call {} validated-echo-cb "(require \"something\")")
         error (unwrap-result res)]
     (is (not (success? res)) "(require \"something\") should NOT succeed")
     (is (valid-eval-error? error) "(require \"something\") should result in an js/Error")
     (is (re-find #"Argument to require must be a symbol" (extract-message error)) "(require \"something\") should have correct error")
     (repl/reset-env!))
-  (let [res (repl/read-eval-call {} echo-callback "(require 'something.ns)")
+  (let [res (repl/read-eval-call {} validated-echo-cb "(require 'something.ns)")
         out (unwrap-result res)]
     (is (success? res) "(require 'something.ns) should succeed")
     (is (valid-eval-result? out) "(require 'something.ns) should be a valid result")
     (is (= "nil" out) "(require 'something.ns) should return nil")
     (repl/reset-env!))
 
-  (let [res (do (repl/read-eval-call {} echo-callback "(ns a.ns)")
-                (repl/read-eval-call {} echo-callback "(def a 3)")
-                (repl/read-eval-call {} echo-callback "(ns b.ns)")
-                (repl/read-eval-call {} echo-callback "(require 'a.ns)"))
+  (let [res (do (repl/read-eval-call {} validated-echo-cb "(ns a.ns)")
+                (repl/read-eval-call {} validated-echo-cb "(def a 3)")
+                (repl/read-eval-call {} validated-echo-cb "(ns b.ns)")
+                (repl/read-eval-call {} validated-echo-cb "(require 'a.ns)"))
         out (unwrap-result res)]
     (is (success? res) "(require 'a.ns) from b.ns should succeed")
     (is (valid-eval-result? out) "(require 'a.ns) from b.ns should be a valid result")
     (is (= 'b.ns (repl/current-ns)) "(require 'a.ns) from b.ns should not change namespace")
     (repl/reset-env! ['a.ns 'b.ns]))
 
-  (let [res (do (repl/read-eval-call {} echo-callback "(ns c.ns)")
-                (repl/read-eval-call {} echo-callback "(def referred-a 3)")
-                (repl/read-eval-call {} echo-callback "(ns d.ns)")
-                (repl/read-eval-call {} echo-callback "(require '[c.ns :refer [referred-a]])")
-                (repl/read-eval-call {} echo-callback "referred-a"))
+  (let [res (do (repl/read-eval-call {} validated-echo-cb "(ns c.ns)")
+                (repl/read-eval-call {} validated-echo-cb "(def referred-a 3)")
+                (repl/read-eval-call {} validated-echo-cb "(ns d.ns)")
+                (repl/read-eval-call {} validated-echo-cb "(require '[c.ns :refer [referred-a]])")
+                (repl/read-eval-call {} validated-echo-cb "referred-a"))
         out (unwrap-result res)]
     (is (success? res) "(require '[c.ns :refer [referred-a]]) should succeed")
     (is (valid-eval-result? out) "(require '[c.ns :refer [referred-a]]) should have a valid result")
@@ -148,8 +150,9 @@
     (repl/reset-env! ['c.ns 'd.ns])))
 
 (deftest warnings
+
   (let [results (atom [])
-        swapping-callback (fn [r] (swap! results conj r))]
+        swapping-callback (partial repl/validated-call-back! (fn [r] (swap! results conj r)))]
     (let [rs (repl/read-eval-call {} swapping-callback "_arsenununpa42")]
       (is (= 1 (count @results)) "Evaluating an undefined symbol should return one message only")
       (is (not (success? (first @results))) "Evaluating an undefined symbol should not succeed")


### PR DESCRIPTION
This brench is the last piece of the puzzle before releasing, now the return map should contain a :form key with the form returned by `cljs.tools.reader`.

It is not a string but a list so that tool can analyze it as data.

Now testing part!
