### PR TITLE
Add facilities for Node.js

### DIFF
--- a/src/cljs/replumb/load.cljs
+++ b/src/cljs/replumb/load.cljs
@@ -1,4 +1,5 @@
-(ns replumb.load)
+(ns replumb.load
+  (:require [clojure.string :as string]))
 
 ;; From mfikes/planck
 ;; For now there is no load from file
@@ -15,3 +16,48 @@
   [{:keys [name macros path file] :as full} cb]
   (cb {:lang   :js
        :source ""}))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; File-based load-fn infrastructure ;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn- filename->lang
+  "Converts a filename to a lang keyword by inspecting the file
+  extension."
+  [filename]
+  (if (string/ends-with? filename ".js")
+    :js
+    :clj))
+
+(defn- read-some
+  "Reads the first filename in a sequence of supplied filenames,
+  using a supplied read-file-fn, calling back upon first successful
+  read, otherwise calling back with nil."
+  [[filename & more-filenames] read-file-fn cb]
+  (if filename
+    (read-file-fn
+      filename
+      (fn [source]
+        (if source
+          (cb {:lang   (filename->lang filename)
+               :source source})
+          (read-some more-filenames read-file-fn cb))))
+    (cb nil)))
+
+(defn- filenames-to-try
+  "Produces a sequence of filenames to try reading, in the
+  order they should be tried."
+  [src-paths macros path]
+  (let [extensions (if macros
+                     [".clj" ".cljc"]
+                     [".cljs" ".cljc" ".js"])]
+    (for [extension extensions
+          src-path src-paths]
+      (str src-path "/" path extension))))
+
+(defn make-load-fn
+  "Makes a load function that will read from a sequence of src-paths
+  using a supplied read-file-fn."
+  [src-paths read-file-fn]
+  (fn [{:keys [macros path]} cb]
+    (read-some (filenames-to-try src-paths macros path) read-file-fn cb)))

--- a/src/cljs/replumb/node.cljs
+++ b/src/cljs/replumb/node.cljs
@@ -1,0 +1,56 @@
+(ns replumb.node
+  "Utilities for operating within Node.js"
+  (:require [replumb.core :as replumb]
+            [replumb.load :as load]
+            [cljs.nodejs :as nodejs]))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; File-based load-fn ;;;
+;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(def fs (nodejs/require "fs"))
+
+(defn- node-read-file
+  "Accepts a filename to read and a callback. Upon success, invokes
+  callback with the source. Otherwise invokes the callback with nil."
+  [filename cb]
+  (.readFile fs filename "utf-8"
+    (fn [err source]
+      (cb (when-not err
+            source)))))
+
+(defn make-load-fn
+  "Makes a load-fn for use within Node.js that will search for source
+  files in a supplied sequence of src-paths."
+  [src-paths]
+  (load/make-load-fn src-paths node-read-file))
+
+;;;;;;;;;;;;;;;;;;;
+;;; Simple REPL ;;;
+;;;;;;;;;;;;;;;;;;;
+
+(defn read-eval-print-loop
+  [load-fn]
+  (let [node-readline (nodejs/require "readline")
+        rl (.createInterface node-readline
+             #js {:input  (.-stdin js/process)
+                  :output (.-stdout js/process)})]
+    (doto rl
+      (.setPrompt (replumb/get-prompt))
+      (.on "line"
+        (fn [cmd]
+          (replumb/read-eval-call
+            {:verbose  false
+             :load-fn! load-fn}
+            (fn [res]
+              (-> res
+                replumb/result->string
+                println)
+              (.setPrompt rl (replumb/get-prompt))
+              (.prompt rl))
+            cmd)))
+      (.prompt))))
+
+(comment
+  (read-eval-print-loop (make-load-fn ["src" "/foo/src2"]))
+  )


### PR DESCRIPTION
- Sets up some infrastructure for producing a
  load-fn that will search a given set of src-paths
  for source files, honoring the extension search
  orderings requried by cljs.js for macro and
  runtime files.

Adds some code to:
- Load files from filesystem in Node.js
- Implement a simple REPL in Node.js
