### PR TITLE
Warning as error

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The first parameter is a map of configuration options, currently
 supporting:
 
 * `:verbose`  will enable the the evaluation logging, defaults to false
-
+* `:warning-as-error`  will consider a compiler warning as error
 * `:target`  `:nodejs` and `:browser` supported, the latter used if missing
 * `:init-fn!`  user provided initialization function, it will be passed a map:
 

--- a/doc/replumb.core.html
+++ b/doc/replumb.core.html
@@ -47,7 +47,8 @@ nil.
 <p>The first parameter is a map of configuration options, currently supporting:</p>
 <ul>
   <li><code>:verbose</code> will enable the the evaluation logging, defaults to false</li>
-  <li><code>:target</code> <code>:nodejs</code> and <code>:browser</code> supported, the latter used if missing</li>
+  <li><code>:warning-as-error</code> will consider a compiler warning as error</li>
+  <li><code>:target</code> <code>:nodejs</code> and <code>:browser</code> supported, the latter is used if missing</li>
   <li><code>:init-fn!</code> user provided initialization function, it will be passed a map:
     <pre><code>:form   ;; the form to evaluate, as data
 :ns     ;; the current namespace, as symbol

--- a/src/cljs/replumb/core.cljs
+++ b/src/cljs/replumb/core.cljs
@@ -11,7 +11,9 @@
   supporting:
 
   * `:verbose` will enable the the evaluation logging, defaults to false
-  * `:target` `:nodejs` and `:browser` supported, the latter used if missing
+  * `:warning-as-error` will consider a compiler warning as error
+  * `:target` `:nodejs` and `:browser` supported, the latter is used if
+  missing
   * `:init-fn!` user provided initialization function, it will be passed a
   map:
 

--- a/src/cljs/replumb/options.cljs
+++ b/src/cljs/replumb/options.cljs
@@ -6,7 +6,7 @@
 
 (def valid-opts-set
   "Set of valid option used for external input validation."
-  #{:verbose :no-warning-error :target :init-fn!
+  #{:verbose :warning-as-error :target :init-fn!
     :load-fn! :read-file-fn! :src-paths})
 
 (defn valid-opts

--- a/src/cljs/replumb/repl.cljs
+++ b/src/cljs/replumb/repl.cljs
@@ -249,10 +249,10 @@
   "Checks if there has been a warning and if so will return the correct
   error map instead of the input one. Note that if the input map was
   already an :error, the warning will be ignored.
-  If :no-warning-error is true in opts the warning remains a warning,
-  not emitting errors."
-  [opts {:keys [value error] :as original-res}]
-  (if (or error (:no-warning-error opts))
+  If (:warning-as-error opts) is truey, in case of warning it will
+  return a with :error."
+  [opts {:keys [error] :as original-res}]
+  (if (or error (not (:warning-as-error opts)))
     original-res
     (if-let [warning-msg (:last-eval-warning @app-env)]
       (let [warning-error (ex-info warning-msg ex-info-data)]
@@ -279,8 +279,7 @@
 
   * :verbose will enable the the evaluation logging, defaults to false.
   * :no-pr-str-on-value avoids wrapping successful value in a pr-str
-  * :no-warning-error will consider a warning like a warning, not
-  emitting errors
+  * :warning-as-error will consider a warning like an error
 
   Notes:
   1. The opts map passed here overrides the environment options.
@@ -461,7 +460,8 @@
   The first parameter is a map of configuration options, currently
   supporting:
 
-  * :verbose   will enable the the evaluation logging, defaults to false
+  * :verbose  will enable the the evaluation logging, defaults to false
+  * :warning-as-error  will consider a compiler warning as error
   * :target  :nodejs and :browser supported, the latter used if missing
   * :init-fn!  user provided initialization function, it will be passed
   a map of data currently containing:

--- a/src/cljs/replumb/repl.cljs
+++ b/src/cljs/replumb/repl.cljs
@@ -462,7 +462,8 @@
 
   * :verbose  will enable the the evaluation logging, defaults to false
   * :warning-as-error  will consider a compiler warning as error
-  * :target  :nodejs and :browser supported, the latter used if missing
+  * :target :nodejs and :browser supported, the latter is used if
+  missing
   * :init-fn!  user provided initialization function, it will be passed
   a map of data currently containing:
 
@@ -527,7 +528,7 @@
       (call-back! opts cb {} (common/wrap-error e)))))
 
 (defn reset-env!
-  "It dons the following (in order):
+  "It does the following (in order):
 
   1. remove the input namespaces from the compiler environment
   2. set *e to nil

--- a/test/cljs/replumb/options_test.cljs
+++ b/test/cljs/replumb/options_test.cljs
@@ -6,7 +6,7 @@
   ;; AR - just not to forget adding them in valid-opts-set
   (let [opts {:verbose :true
               :load-fn! "fn"
-              :no-warning-error true
+              :warning-as-error true
               :target "default"
               :init-fn! "fn"
               :read-file-fn! "fn"
@@ -37,3 +37,6 @@
   (is (nil? (:load-fn! (normalize-opts {:src-paths {} :read-file-fn! #()}))) "Must create :load-fn! only when :src-paths is sequential")
   (is (nil? (:read-file-fn! (normalize-opts {:src-paths ["src"] :read-file-fn! #()}))) "Must elide :read-file-fn! after having created :load-fn!")
   (is (not (nil? (:load-fn! (normalize-opts {:src-paths ["src"] :read-file-fn! #()})))) "Must create a brand new :load-fn! when :read-file-fn! is present"))
+
+(deftest options-warning
+  (is (= true (:warning-as-error (normalize-opts {:warning-as-error true}))) "Option :warning-as-error should be carried over"))

--- a/test/cljs/replumb/repl_test.cljs
+++ b/test/cljs/replumb/repl_test.cljs
@@ -127,17 +127,17 @@
   (set! js/COMPILED false))
 
 (deftest process-ns
-  (let [res (repl/read-eval-call {} validated-echo-cb "(ns 'first.namespace)")
+  (let [res (repl/read-eval-call {} validated-echo-cb "(ns 'something.ns)")
         error (unwrap-result res)]
-    (is (not (success? res)) "(ns 'something) should NOT succeed")
-    (is (valid-eval-error? error) "(ns 'something) should result in an js/Error")
-    (is (re-find #"Namespaces must be named by a symbol" (extract-message error)) "(ns 'something) should have correct error")
+    (is (not (success? res)) "(ns 'something.ns) should NOT succeed")
+    (is (valid-eval-error? error) "(ns 'something.ns) should result in an js/Error")
+    (is (re-find #"Namespaces must be named by a symbol" (extract-message error)) "(ns 'something.ns) should have correct error")
     (repl/reset-env!))
   (let [res (repl/read-eval-call {} validated-echo-cb "(ns my.namespace)")
         out (unwrap-result res)]
-    (is (success? res) "(ns something) should succeed")
-    (is (valid-eval-result? out) "(ns something) should be a valid result")
-    (is (= "nil" out) "(ns something) should return \"nil\"")
+    (is (success? res) "(ns my.namespace) should succeed")
+    (is (valid-eval-result? out) "(ns my.namespace) should be a valid result")
+    (is (= "nil" out) "(ns my.namespace) should return \"nil\"")
     (repl/reset-env! ['my.namespace])))
 
 ;; AR - with fake load, we want to test functionality that don't depend on
@@ -168,7 +168,7 @@
       (is (success? res) "(require 'something.ns) should succeed")
       (is (valid-eval-result? out) "(require 'something.ns) should be a valid result")
       (is (= "nil" out) "(require 'something.ns) should return nil")
-      (repl/reset-env!))
+      (repl/reset-env! ['something.ns]))
 
     (let [res (do (repl/read-eval-call {} validated-echo-cb "(ns a.ns)")
                   (repl/read-eval-call {} validated-echo-cb "(def a 3)")


### PR DESCRIPTION
This adds the possibility (was already there, but working in the opposite way and not exposed to client code yet) of considering warnings as error, therefore receiving them as `{:error ...}` in the `read-eval-call` callback.
