### PR TITLE
Remove -fn keys when printing opts/verbose.

### DIFF
--- a/src/cljs/replumb/common.cljs
+++ b/src/cljs/replumb/common.cljs
@@ -84,6 +84,12 @@
   [symbol ex-info-data]
   (wrap-error (ex-info (str "Argument to " symbol " must be a symbol") ex-info-data)))
 
+(defn filter-fn-keys
+  "Filter out the option map keys that have -fn in it."
+  [opts]
+  {:pre [(map? opts)]}
+  (into {} (filter #(not (re-find #"-fn" (name (first %)))) opts)))
+
 (defn debug-prn
   [& args]
   (binding [cljs.core/*print-fn* cljs.core/*print-err-fn*]

--- a/src/cljs/replumb/repl.cljs
+++ b/src/cljs/replumb/repl.cljs
@@ -294,7 +294,9 @@
    (call-back! opts cb {} res))
   ([opts cb data res]
    (when (:verbose opts)
-     (common/debug-prn "Calling back!\n" (with-out-str (pprint {:opts opts :data data :res res}))))
+     (common/debug-prn "Calling back!\n" (with-out-str (pprint {:opts (common/filter-fn-keys opts)
+                                                                :data data
+                                                                :res res}))))
    (let [new-map (warning-error-map! opts res)]
      (let [{:keys [value error]} new-map]
        (call-side-effect! data new-map)
@@ -505,7 +507,7 @@
                 :target (keyword *target*)}]
       (init-repl-if-necessary! opts data)
       (when (:verbose opts)
-        (common/debug-prn "Evaluating " expression-form " with options " opts))
+        (common/debug-prn "Evaluating " expression-form " with options " (common/filter-fn-keys opts)))
       (binding [ana/*cljs-warning-handlers* [(partial custom-warning-handler opts cb)]]
         (if (repl-special? expression-form)
           (process-repl-special opts cb data expression-form)

--- a/test/cljs/replumb/common_test.cljs
+++ b/test/cljs/replumb/common_test.cljs
@@ -1,6 +1,6 @@
 (ns ^:figwheel-load replumb.common-test
   (:require [cljs.test :refer-macros [deftest is]]
-            [replumb.common :as common :refer [extract-message]]))
+            [replumb.common :as common :refer [extract-message filter-fn-keys]]))
 
 (def empty-err {})
 (def single-err #(ex-info "Could not eval -)" {:tag :cljs/reader-exception}))
@@ -28,3 +28,9 @@
     (is (string? msg)))
   (let [msg (extract-message (err-with-ERROR) true)]
     (is (re-find #"Write this.*and this please" msg))))
+
+(deftest filter-fn-key
+  (is (map? (filter-fn-keys {:load-fn! #() :verbose true})) "The result of filter-fn-keys should be a map")
+  (is (= [:verbose] (keys (filter-fn-keys {:load-fn! #() :init-fn! #() :verbose true}))) "Keys with -fn should not pass through filter-fn-keys")
+  (is (= (empty? (keys (filter-fn-keys {:load-fn! #() :init-fn-testing #()})))) "If all keys have -fn then filter-fn-keys result should be empty")
+  (is (= {:verbose true} (filter-fn-keys {:verbose true})) "When there are no -fn key then filter-fn-keys result should be same as the input"))


### PR DESCRIPTION
This will remove all the verbose printing (that we can control) of the keys that have `-fn` in it.
They are too verbose and we don't need them in the log. If we will need them, we can add more customizable options to `:verbose`.
