### PR TITLE
Source

### DIFF
--- a/src/cljs/replumb/load.cljs
+++ b/src/cljs/replumb/load.cljs
@@ -42,7 +42,7 @@
                                  (read-files-and-callback! verbose? (rest file-names) read-file-fn load-fn-cb))))))
     (load-fn-cb nil)))
 
-(defn filenames-to-try
+(defn file-paths-to-try
   "Produces a sequence of filenames to try reading, in the
   order they should be tried."
   [src-paths macros file-path]
@@ -54,7 +54,14 @@
       ;; AR - will there be a need for https://nodejs.org/docs/latest/api/path.html ?
       (str (common/normalize-path src-path) file-path extension))))
 
-(defn goog-filenames-to-try
+(defn file-paths-to-try-from-ns-symbol
+  "Given the symbol of a namespace produces all possibile file names
+  in which given ns could be found."
+  [ns-sym src-paths]
+  (let [without-extension (string/replace (string/replace (name ns-sym) #"\." "/") #"-" "_")]
+    (file-paths-to-try src-paths false without-extension)))
+
+(defn goog-file-paths-to-try
   "Produces a sequence of filenames to try reading crafted for goog
   libraries, in the order they should be tried."
   [src-paths goog-path]

--- a/test/browser/launcher/runner.cljs
+++ b/test/browser/launcher/runner.cljs
@@ -5,6 +5,7 @@
             replumb.common-test
             replumb.load-test
             replumb.options-test
-            replumb.require-browser-test))
+            replumb.require-browser-test
+            replumb.source-browser-test))
 
 (doo-all-tests #"^replumb.*-test")

--- a/test/browser/replumb/source_browser_test.cljs
+++ b/test/browser/replumb/source_browser_test.cljs
@@ -1,0 +1,4 @@
+(ns replumb.source-browser-test)
+
+;; Same as with require tests - this is not possible with phantom/slimer at the
+;; moment.

--- a/test/cljs/replumb/load_test.cljs
+++ b/test/cljs/replumb/load_test.cljs
@@ -1,23 +1,23 @@
 (ns ^:figwheel-load replumb.load-test
   (:require [cljs.test :refer-macros [deftest is]]
             [clojure.string :as string]
-            [replumb.load :refer [filenames-to-try]]))
+            [replumb.load :refer [file-paths-to-try]]))
 
 (deftest files
-  (is (empty? (filenames-to-try [] true "temp")) "No files should be tried with empty source path and if :macros true")
-  (is (empty? (filenames-to-try [] false "temp")) "No files should be tried with empty source path and if :macros false")
+  (is (empty? (file-paths-to-try [] true "temp")) "No files should be tried with empty source path and if :macros true")
+  (is (empty? (file-paths-to-try [] false "temp")) "No files should be tried with empty source path and if :macros false")
   (let [src-paths ["src1/foo" "src2/" "src3/foo/bar"]
         file "core"
         cljs-files (map #(str % (when-not (= "/" (last %)) "/") file ".cljs") src-paths)
         cljc-files (map #(str % (when-not (= "/" (last %)) "/") file ".cljc") src-paths)
         clj-files (map #(str % (when-not (= "/" (last %)) "/") file ".clj") src-paths)
         js-files (map #(str % (when-not (= "/" (last %)) "/") file ".js") src-paths)]
-    (let [files (into [] (filenames-to-try src-paths false file))]
+    (let [files (into [] (file-paths-to-try src-paths false file))]
       (is (= 9 (count files)) "With 3 paths 9 files should be tried if :macros false")
       (is (= cljs-files (subvec files 0 3)) "Try .cljs files first if :macros false")
       (is (= cljc-files (subvec files 3 6)) "Try .cljc files second if :macros false")
       (is (= js-files (subvec files 6)) "Try .js files third if :macros false"))
-    (let [files (into [] (filenames-to-try src-paths true file))]
+    (let [files (into [] (file-paths-to-try src-paths true file))]
       (is (= 6 (count files)) "With 3 paths 6 files should be tried if :macros true")
       (is (= clj-files (subvec files 0 3)) "Try .clj files first if :macros true")
       (is (= cljc-files (subvec files 3)) "Try .cljc files second if :macros true"))))

--- a/test/node/launcher/runner.cljs
+++ b/test/node/launcher/runner.cljs
@@ -5,6 +5,7 @@
             replumb.common-test
             replumb.load-test
             replumb.options-test
-            replumb.require-node-test))
+            replumb.require-node-test
+            replumb.source-node-test))
 
 (doo-all-tests #"^replumb.*-test")

--- a/test/node/replumb/source_node_test.cljs
+++ b/test/node/replumb/source_node_test.cljs
@@ -1,0 +1,91 @@
+(ns replumb.source-node-test
+  (:require [cljs.test :refer-macros [deftest is]]
+            [cljs.nodejs :as nodejs]
+            [doo.runner :as doo]
+            [replumb.core :as core :refer [nodejs-options success? unwrap-result]]
+            [replumb.common :as common :refer [echo-callback valid-eval-result?
+                                               extract-message valid-eval-error?]]
+            [replumb.repl :as repl]
+            [replumb.nodejs.io :as io]))
+
+(let [src-paths ["dev-resources/private/test/node/compiled/out"
+                 "dev-resources/private/test/src/cljs"
+                 "dev-resources/private/test/src/clj"]
+      validated-echo-cb (partial repl/validated-call-back! echo-callback)
+      target-opts (nodejs-options src-paths io/read-file!)
+      read-eval-call (partial repl/read-eval-call target-opts validated-echo-cb)]
+
+  (deftest source-in-cljs-core
+    (let [res (read-eval-call "(source max)")
+          source-string (unwrap-result res)
+          expected "(defn ^number max
+  \"Returns the greatest of the nums.\"
+  ([x] x)
+  ([x y] (cljs.core/max x y))
+  ([x y & more]
+   (reduce max (cljs.core/max x y) more)))"]
+      (is (success? res) "(source max) should succeed.")
+      (is (valid-eval-result? source-string) "(source max) should be a valid result")
+      (is (= expected source-string) "(source max) should return valid source")
+      (repl/reset-env!))
+
+    (let [res (read-eval-call "(source nil?)")
+          source-string (unwrap-result res)
+          expected "(defn ^boolean nil?
+  \"Returns true if x is nil, false otherwise.\"
+  [x]
+  (coercive-= x nil))"]
+      (is (success? res) "(source nil?) should succeed.")
+      (is (valid-eval-result? source-string) "(source nil?) should be a valid result")
+      (is (= expected source-string) "(source nil?) should return valid source")
+      (repl/reset-env!)))
+
+  (deftest source-in-non-core-ns
+    (let [res (do (read-eval-call "(require 'clojure.set)")
+                  (read-eval-call "(source clojure.set/union)"))
+          source-string (unwrap-result res)
+          expected "(defn union
+  \"Return a set that is the union of the input sets\"
+  ([] #{})
+  ([s1] s1)
+  ([s1 s2]
+     (if (< (count s1) (count s2))
+       (reduce conj s2 s1)
+       (reduce conj s1 s2)))
+  ([s1 s2 & sets]
+     (let [bubbled-sets (bubble-max-key count (conj sets s2 s1))]
+       (reduce into (first bubbled-sets) (rest bubbled-sets)))))"]
+      (is (success? res) "(source clojure.set/union) should succeed.")
+      (is (valid-eval-result? source-string) "(source clojure.set/union) should be a valid result")
+      (is (= expected source-string) "(source clojure.set/union) should return valid source")
+      (repl/reset-env! ['clojure.set]))
+
+    (let [res (do (read-eval-call "(require 'clojure.string)")
+                  (read-eval-call "(source clojure.string/trim)"))
+          source-string (unwrap-result res)
+          expected "(defn trim
+  \"Removes whitespace from both ends of string.\"
+  [s]
+  (gstring/trim s))"]
+      (is (success? res) "(source clojure.string/trim) should succeed.")
+      (is (valid-eval-result? source-string) "(source clojure.string/trim) should be a valid result")
+      (is (= expected source-string) "(source clojure.string/trim) should return valid source")
+      (repl/reset-env! ['clojure.string])))
+
+  (deftest source-in-custom-ns
+    (let [res (do (read-eval-call "(require 'foo.bar.baz)")
+                  (read-eval-call "(source foo.bar.baz/a)"))
+          source-string (unwrap-result res)
+          expected "(def a \"whatever\")"]
+      (is (success? res) "(source foo.bar.baz/a) should succeed.")
+      (is (valid-eval-result? source-string) "(source foo.bar.baz/a) should be a valid result")
+      (is (= expected source-string) "(source foo.bar.baz/a) should return valid source")
+      (repl/reset-env! ['foo.bar.baz])))
+
+  ;; see "RUNNING TESTS" section for explanation of `test-ns-hook` special function
+  ;; https://clojure.github.io/clojure/clojure.test-api.html
+  (defn test-ns-hook []
+    (repl/force-init!)
+    (source-in-cljs-core)
+    (source-in-non-core-ns)
+    (source-in-custom-ns)))

--- a/test/node/replumb/source_node_test.cljs
+++ b/test/node/replumb/source_node_test.cljs
@@ -13,7 +13,11 @@
                  "dev-resources/private/test/src/clj"]
       validated-echo-cb (partial repl/validated-call-back! echo-callback)
       target-opts (nodejs-options src-paths io/read-file!)
-      read-eval-call (partial repl/read-eval-call target-opts validated-echo-cb)]
+      read-eval-call (partial repl/read-eval-call target-opts validated-echo-cb)
+      fake-read-file-fn (fn [path cb] (cb nil))
+      read-eval-call-fake-read-file (partial repl/read-eval-call
+                                             (merge target-opts {:read-file-fn! fake-read-file-fn})
+                                             validated-echo-cb)]
 
   (deftest source-in-cljs-core
     (let [res (read-eval-call "(source max)")
@@ -38,6 +42,13 @@
       (is (success? res) "(source nil?) should succeed.")
       (is (valid-eval-result? source-string) "(source nil?) should be a valid result")
       (is (= expected source-string) "(source nil?) should return valid source")
+      (repl/reset-env!))
+
+    (let [res (read-eval-call "(source not-existing)")
+          source-string (unwrap-result res)]
+      (is (success? res) "(source not-existing) should succeed.")
+      (is (valid-eval-result? source-string) "(source not-existing) should be a valid result")
+      (is (= "nil" source-string) "(source not-existing) should return nil")
       (repl/reset-env!)))
 
   (deftest source-in-non-core-ns
@@ -70,6 +81,14 @@
       (is (success? res) "(source clojure.string/trim) should succeed.")
       (is (valid-eval-result? source-string) "(source clojure.string/trim) should be a valid result")
       (is (= expected source-string) "(source clojure.string/trim) should return valid source")
+      (repl/reset-env! ['clojure.string]))
+
+    (let [res (do (read-eval-call "(require 'clojure.string)")
+                  (read-eval-call "(source clojure.string/not-existing)"))
+          source-string (unwrap-result res)]
+      (is (success? res) "(source clojure.string/not-existing) should succeed.")
+      (is (valid-eval-result? source-string) "(source clojure.string/not-existing) should be a valid result")
+      (is (= "nil" source-string) "(source clojure.string/not-existing) should return valid source")
       (repl/reset-env! ['clojure.string])))
 
   (deftest source-in-custom-ns
@@ -80,7 +99,15 @@
       (is (success? res) "(source foo.bar.baz/a) should succeed.")
       (is (valid-eval-result? source-string) "(source foo.bar.baz/a) should be a valid result")
       (is (= expected source-string) "(source foo.bar.baz/a) should return valid source")
-      (repl/reset-env! ['foo.bar.baz])))
+      (repl/reset-env! ['foo.bar.baz]))
+
+    (let [res (do (read-eval-call "(require 'clojure.string)")
+                  (read-eval-call-fake-read-file "(source clojure.string/trim)"))
+          source-string (unwrap-result res)]
+      (is (success? res) "(source clojure.string/trim) should succeed.")
+      (is (valid-eval-result? source-string) "(source clojure.string/trim) should be a valid result")
+      (is (= "nil" source-string) "(source clojure.string/trim) should return nil")
+      (repl/reset-env! ['clojure.string])))
 
   ;; see "RUNNING TESTS" section for explanation of `test-ns-hook` special function
   ;; https://clojure.github.io/clojure/clojure.test-api.html


### PR DESCRIPTION
Initial functionality for `source`. Needs some adjustments (probably is related to other issues).
Now these two don't work: `(source when)` and 

```
(require '[clojure.set :as s])
(source s/union)
```
