### PR TITLE
Nil returning tests

### DIFF
--- a/src/cljs/replumb/repl.cljs
+++ b/src/cljs/replumb/repl.cljs
@@ -508,15 +508,15 @@
                                  read-file-fn!
                                  (fn [result]
                                    (if result
-                                    (let [source (:source result)
-                                          rdr (rt/source-logging-push-back-reader source)]
-                                      (dotimes [_ (dec (:line var))] (rt/read-line rdr))
-                                      (-> (r/read {:read-cond :allow :features #{:cljs}} rdr)
-                                          meta 
-                                          :source
-                                          common/wrap-success
-                                          cb))
-                                    (cb (common/wrap-success "nil"))))))
+                                     (let [source (:source result)
+                                           rdr (rt/source-logging-push-back-reader source)]
+                                       (dotimes [_ (dec (:line var))] (rt/read-line rdr))
+                                       (-> (r/read {:read-cond :allow :features #{:cljs}} rdr)
+                                           meta
+                                           :source
+                                           common/wrap-success
+                                           cb))
+                                     (cb (common/wrap-success "nil"))))))
 
 (defn process-source
   [opts cb data env sym]
@@ -722,6 +722,9 @@
   ([namespaces]
    (doseq [ns namespaces]
      (purge-ns! st (symbol ns)))
+   (if (seq @cljs.js/*loaded*)
+     (throw (ex-info (str "The cljs.js/*loaded* atom still contains " @cljs.js/*loaded* " - make sure you purge dependent namespaces.") ex-info-data)))
+   (assert (empty? @cljs.js/*loaded*))
    (reset-last-warning!)
    (read-eval-call {} identity "(set! *e nil)")
    (read-eval-call {} identity "(in-ns 'cljs.user)")))

--- a/test/cljs/replumb/repl_test.cljs
+++ b/test/cljs/replumb/repl_test.cljs
@@ -279,6 +279,7 @@
       (is (valid-eval-result? out) "Executing (defmacro hello ..) as function should have a valid result")
       (is (= "(inc 13)" out) "Executing (defmacro hello ..) as function shoud return (inc 13)")
       (repl/reset-env!))
+
     (let [res (do (read-eval-call "(ns foo.core$macros)")
                   (read-eval-call "(defmacro hello [x] (prn &form) `(inc ~x))")
                   (read-eval-call "(foo.core/hello (+ 2 3))"))
@@ -286,7 +287,8 @@
       (is (success? res) "Executing (foo.core/hello ..) as function should succeed")
       (is (valid-eval-result? out) "Executing (foo.core/hello ..) hello ..) as function should have a valid result")
       (is (= "6" out) "Executing (foo.core/hello ..) hello ..) as function shoud return 6")
-      (repl/reset-env! ["foo.core$macros"]))
+      (repl/reset-env! '[foo.core]))
+
     (let [res (do (read-eval-call "(ns foo.core$macros)")
                   (read-eval-call "(defmacro hello [x] (prn &form) `(inc ~x))")
                   (read-eval-call "(ns another.ns)")
@@ -296,7 +298,7 @@
       (is (success? res) "Executing (foo.core/hello ..) as function should succeed")
       (is (valid-eval-result? out) "Executing (foo.core/hello ..) hello ..) as function should have a valid result")
       (is (= "6" out) "Executing (foo.core/hello ..) hello ..) as function shoud return 6")
-      (repl/reset-env! ["foo.core$macros"])))
+      (repl/reset-env! '[foo.core])))
 
   (deftest tagged-literals
     ;; AR - Don't need to test more as ClojureScript already has extensive tests on this


### PR DESCRIPTION
This PR puts some assert around `replumb.repl/reset-env!` so that we won't forget to purge namespaces in tests anymore.

Other then that, refactors, add and fixes some test for both `source` and `require`.
