### PR TITLE
Source fix 86

### DIFF
--- a/src/cljs/replumb/repl.cljs
+++ b/src/cljs/replumb/repl.cljs
@@ -51,10 +51,15 @@
   ([state ns]
    {:pre [(symbol? ns)]}
    (->> (merge
-          (get-in @state [::ana/namespaces ns :macros])
-          (get-in @state [::ana/namespaces ns :defs]))
+         (get-in @state [:cljs.analyzer/namespaces ns :macros])
+         (get-in @state [:cljs.analyzer/namespaces ns :defs]))
         (remove (fn [[k v]] (:private v)))
         (into {}))))
+
+(defn get-namespace-defs
+  "Given a namespace symbol, returns its AST :defs content"
+  [sym]
+  (get-in @st [:cljs.analyzer/namespaces sym :defs]))
 
 (defn get-namespace
   [sym]
@@ -94,7 +99,7 @@
       (second first-form))))
 
 (defn resolve
-  "From cljs.analizer.api.clj. Given an analysis environment resolve a
+  "From cljs.analyzer.api.clj. Given an analysis environment resolve a
   var. Analogous to clojure.core/resolve"
   [opts env sym]
   {:pre [(map? env) (symbol? sym)]}
@@ -172,7 +177,7 @@
 ;; from https://github.com/mfikes/planck/commit/fe9e7b3ee055930523af1ea3ec9b53407ed2b8c8
 (defn purge-ns-analysis-cache!
   [st ns]
-  (swap! st update-in [::ana/namespaces] dissoc ns))
+  (swap! st update-in [:cljs.analyzer/namespaces] dissoc ns))
 
 (defn purge-ns!
   [st ns]

--- a/src/cljs/replumb/repl.cljs
+++ b/src/cljs/replumb/repl.cljs
@@ -218,25 +218,25 @@
 
 (defn make-load-fn
   "Makes a load function that will read from a sequence of src-paths
-  using a supplied read-file-fn. It returns a cljs.js-compatible
+  using a supplied read-file-fn!. It returns a cljs.js-compatible
   *load-fn*.
 
-  Read-file-fn is an async 2-arity function (fn [file-path src-cb] ...)
-  where src-cb is itself a function (fn [source] ...) that needs to be
-  called with the full source of the library (as string)."
-  [verbose? src-paths read-file-fn]
+  Read-file-fn! is an async 2-arity function with signature [file-path
+  src-cb] where src-cb is itself a function (fn [source] ...) that needs
+  to be called with the full source of the library (as string)."
+  [verbose? src-paths read-file-fn!]
   (fn [{:keys [name macros path] :as load-map} cb]
     (cond
       (load/skip-load? load-map) (load/fake-load-fn! load-map cb)
       (re-matches #"^goog/.*" path) (if-let [goog-path (get-goog-path name)]
                                       (load/read-files-and-callback! verbose?
                                                                      (load/goog-file-paths-to-try src-paths goog-path)
-                                                                     read-file-fn
+                                                                     read-file-fn!
                                                                      cb)
                                       (cb nil))
       :else (load/read-files-and-callback! verbose?
                                            (load/file-paths-to-try src-paths macros path)
-                                           read-file-fn
+                                           read-file-fn!
                                            cb))))
 
 ;;;;;;;;;;;;;;;;
@@ -270,12 +270,12 @@
   [opts user-opts]
   (assoc opts :load-fn!
          (or (:load-fn! user-opts)
-             (let [read-file-fn (:read-file-fn! user-opts)
+             (let [read-file-fn! (:read-file-fn! user-opts)
                    src-paths (:src-paths user-opts)]
-               (if (and read-file-fn (sequential? src-paths))
+               (if (and read-file-fn! (sequential? src-paths))
                  (make-load-fn (:verbose user-opts)
                                (into [] src-paths)
-                               read-file-fn)
+                               read-file-fn!)
                  (when (:verbose user-opts)
                    (common/debug-prn "Invalid :read-file-fn! or :src-paths (is it a valid sequence?). Cannot create *load-fn*.")))))))
 

--- a/test/node/replumb/require_node_test.cljs
+++ b/test/node/replumb/require_node_test.cljs
@@ -39,6 +39,15 @@
       (is (success? res) "(require ...) and (doc clojure.string/trim) should succeed.")
       (is (valid-eval-result? docstring) "(require ...) and (doc clojure.string/trim) should be a valid result")
       (is (re-find #"Removes whitespace from both ends of string" docstring) "(require ...) and (doc clojure.string/trim) should return valid docstring")
+      (repl/reset-env! '[clojure.string goog.string goog.string.StringBuffer]))
+
+    ;; https://github.com/ScalaConsultants/replumb/issues/86
+    (let [res (do (read-eval-call "(require '[clojure.string :as string])")
+                  (read-eval-call "(doc string/trim)"))
+          docstring (unwrap-result res)]
+      (is (success? res) "(require '[clojure.string :as string]) and (doc string/trim) should succeed.")
+      (is (valid-eval-result? docstring) "(require '[clojure.string :as string]) and (doc string/trim) should be a valid result")
+      (is (re-find #"Removes whitespace from both ends of string" docstring) "(require '[clojure.string :as string]) and (doc string/trim) should return valid docstring")
       (repl/reset-env! '[clojure.string goog.string goog.string.StringBuffer])))
 
   (deftest require+dir

--- a/test/node/replumb/source_node_test.cljs
+++ b/test/node/replumb/source_node_test.cljs
@@ -86,6 +86,15 @@
       (is (success? res) "(source clojure.string/not-existing) should succeed.")
       (is (valid-eval-result? source-string) "(source clojure.string/not-existing) should be a valid result")
       (is (= "nil" source-string) "(source clojure.string/not-existing) should return valid source")
+      (repl/reset-env! '[clojure.string goog.string goog.string.StringBuffer]))
+
+    ;; https://github.com/ScalaConsultants/replumb/issues/86
+    (let [res (do (read-eval-call "(require '[clojure.string :as s])")
+                  (read-eval-call "(source s/trim)"))
+          docstring (unwrap-result res)]
+      (is (success? res) "(require '[clojure.string :as s]) and (doc s/trim) should succeed.")
+      (is (valid-eval-result? docstring) "(require '[clojure.string :as s]) and (doc s/trim) should be a valid result")
+      (is (re-find #"Removes whitespace from both ends of string" docstring) "(require '[clojure.string :as s]) and (doc s/trim) should return valid docstring")
       (repl/reset-env! '[clojure.string goog.string goog.string.StringBuffer])))
 
   (deftest source-in-custom-ns
@@ -96,6 +105,16 @@
       (is (success? res) "(source foo.bar.baz/a) should succeed.")
       (is (valid-eval-result? source-string) "(source foo.bar.baz/a) should be a valid result")
       (is (= expected source-string) "(source foo.bar.baz/a) should return valid source")
+      (repl/reset-env! ['foo.bar.baz]))
+
+    ;; https://github.com/ScalaConsultants/replumb/issues/86
+    (let [res (do (read-eval-call "(require '[foo.bar.baz :as baz])")
+                  (read-eval-call "(source baz/a)"))
+          source-string (unwrap-result res)
+          expected "(def a \"whatever\")"]
+      (is (success? res) "(require '[foo.bar.baz :as baz]) and (source baz/a) should succeed.")
+      (is (valid-eval-result? source-string) "(require '[foo.bar.baz :as baz]) and (source baz/a) should be a valid result")
+      (is (= expected source-string) "(require '[foo.bar.baz :as baz]) and (source baz/a) should return valid source")
       (repl/reset-env! ['foo.bar.baz])))
 
   ;; see "RUNNING TESTS" section for explanation of `test-ns-hook` special function


### PR DESCRIPTION
I don't know why, `(source s/trim)` is now working at the repl.
I will try to understand what happened.
