### PR TITLE
Test requiring macros with ns. Closes #64.

### DIFF
--- a/dev-resources/private/test/src/clj/foo/bar.cljc
+++ b/dev-resources/private/test/src/clj/foo/bar.cljc
@@ -1,1 +1,0 @@
-(ns foo.bar)

--- a/dev-resources/private/test/src/clj/foo/baz.clj
+++ b/dev-resources/private/test/src/clj/foo/baz.clj
@@ -1,1 +1,5 @@
 (ns foo.baz)
+
+(defmacro mul
+  [a b]
+  `(* ~a ~b))

--- a/dev-resources/private/test/src/clj/foo/test.cljc
+++ b/dev-resources/private/test/src/clj/foo/test.cljc
@@ -1,0 +1,5 @@
+(ns foo.test)
+
+(defmacro add
+  [a b]
+  `(+ ~a ~b))

--- a/test/cljs/replumb/repl_test.cljs
+++ b/test/cljs/replumb/repl_test.cljs
@@ -287,6 +287,7 @@
       (is (valid-eval-result? out) "(defmacro hello ..) should have a valid result")
       (is (= "true" out) "(defmacro hello ..) shoud return true")
       (repl/reset-env!))
+
     (let [res (do (read-eval-call "(defmacro hello [x] `(inc ~x))")
                   (read-eval-call "(hello nil nil 13)"))
           out (unwrap-result res)]
@@ -313,7 +314,7 @@
       (is (success? res) "Executing (foo.core/hello ..) as function should succeed")
       (is (valid-eval-result? out) "Executing (foo.core/hello ..) hello ..) as function should have a valid result")
       (is (= "6" out) "Executing (foo.core/hello ..) hello ..) as function shoud return 6")
-      (repl/reset-env! '[foo.core])))
+      (repl/reset-env! '[foo.core another.ns])))
 
   (deftest tagged-literals
     ;; AR - Don't need to test more as ClojureScript already has extensive tests on this

--- a/test/node/replumb/require_node_test.cljs
+++ b/test/node/replumb/require_node_test.cljs
@@ -240,6 +240,74 @@
       (is (re-find #"ABCDEF" out) "The result should be ABCDEF")
       (repl/reset-env! '[my.namespace foo.bar.baz])))
 
+  (deftest ns-macro-with-macros
+    (let [res (do (read-eval-call "(ns my.namespace (:require-macros [foo.test]))")
+                  (read-eval-call "(foo.test/add 10 10)"))
+          out (unwrap-result res)]
+      (is (success? res) "(ns my.namespace (:require-macros ...)) and (foo.test/add 10 10) should succeed")
+      (is (valid-eval-result? out) "(ns my.namespace (:require-macros ...)) and (foo.test/add 10 10) should be a valid result.")
+      (is (= "20" out) "(foo.test/add 10 10) should be 20")
+      (repl/reset-env! '[my.namespace foo.test]))
+
+    ;; TB - this test fails but shouldn't, see https://github.com/clojure/clojurescript/wiki/Differences-from-Clojure#lisp
+    ;; see also http://dev.clojure.org/jira/browse/CLJS-1449
+    ;; I'm leaving it here for reference, it needs to be changed when the bug will be resolved
+    (let [res (do (read-eval-call "(ns my.namespace (:require-macros [foo.test :as f]))")
+                  (read-eval-call "(f/add 10 10)"))
+          error (unwrap-result res)]
+      (is (not (success? res)) "(ns my.namespace (:require-macros ...:as...)) and (f/add 10 10) should not succeed")
+      (is (valid-eval-error? error) "(ns my.namespace (:require-macros ...:as...)) and (f/add 10 10) should be an instance of js/Error")
+      ;; (is (= "20" out) "(f/add 10 10) should be 20")
+      (is (re-find #"ERROR" (extract-message error))
+          "(ns my.namespace (:require-macros ...:as...)) and (f/add 10 10) should have correct error message")
+      (repl/reset-env! '[my.namespace foo.test]))
+
+    (let [res (do (read-eval-call "(ns my.namespace (:require-macros [foo.test :refer [add]]))")
+                  (read-eval-call "(add 10 10)"))
+          out (unwrap-result res)]
+      (is (success? res) "(ns my.namespace (:require-macros ... :refer ...)) and (add 10 10) should succeed")
+      (is (valid-eval-result? out) "(ns my.namespace (:require-macros ...:refer...)) and (add 10 10) should be a valid result.")
+      (is (= "20" out) "(add 10 10) should be 20")
+      (repl/reset-env! '[my.namespace foo.test]))
+
+    (let [res (do (read-eval-call "(ns my.namespace (:use-macros [foo.baz :only [mul]]))")
+                  (read-eval-call "(mul 10 10)"))
+          out (unwrap-result res)]
+      (is (success? res) "(ns my.namespace (:use-macros ...)) and (mul 10 10) should succeed")
+      (is (valid-eval-result? out) "(ns my.namespace (:use-macros ...)) and (mul 10 10) should be a valid result.")
+      (is (= "100" out) "(mul 10 10) should be 100")
+      (repl/reset-env! '[my.namespace foo.baz]))
+
+    (let [res (do (read-eval-call "(ns my.namespace (:require [foo.test :as f]))")
+                  (read-eval-call "(f/add 5 7)"))
+          out (unwrap-result res)]
+      (is (success? res) "(ns my.namespace (:require ...)) and (f/add 5 7) should succeed")
+      (is (valid-eval-result? out) "(ns my.namespace (:require ...)) and (f/add 5 7) should be a valid result.")
+      (is (re-find #"\(\+ nil nil\)" out) "(f/add 5 7) should produce (+ nil nil)")
+      (repl/reset-env! '[my.namespace foo.test]))
+
+    (let [res (do (read-eval-call "(ns my.namespace (:require [foo.test :as f :include-macros true]))")
+                  (read-eval-call "(f/add 5 7)"))
+          out (unwrap-result res)]
+      (is (success? res) "(ns my.namespace (:require ...)) and (f/add 5 7) should succeed")
+      (is (valid-eval-result? out) "(ns my.namespace (:require ...)) and (f/add 5 7) should be a valid result.")
+      (is (= "12" out) "(f/add 5 7) should be 12")
+      (repl/reset-env! '[my.namespace foo.test]))
+
+    ;; TB - this test fails but shouldn't, see "Inline macro specifications" section
+    ;; here https://github.com/clojure/clojurescript/wiki/Differences-from-Clojure#namespaces
+    ;; see also http://dev.clojure.org/jira/browse/CLJS-1507
+    ;; I'm leaving it here for reference, it needs to be changed when the bug will be resolved
+    (let [res (do (read-eval-call "(ns my.namespace (:require [foo.baz :refer-macros [mul]]))")
+                  (read-eval-call "(mul 10 12)"))
+          error (unwrap-result res)]
+      (is (not (success? error)) "(ns my.namespace (:require ...)) and (mul 10 12) should not succeed")
+      (is (valid-eval-error? error) "(ns my.namespace (:require ...)) and (mul 10 12) should be an instance of js/Error")
+      ;;(is (= "120" out) "(mul 10 12) should be 120")
+      (is (re-find #"ERROR" (extract-message error))
+          "(ns my.namespace (:require ...)) and (mul 10 12) should have correct error message")
+      (repl/reset-env! '[my.namespace foo.baz])))
+
   (deftest process-reload
     (let [alterable-core-path "dev-resources/private/test/src/cljs/alterable/core.cljs"
           pre-content "(ns alterable.core)\n\n(def b \"pre\")"
@@ -317,6 +385,7 @@
     (process-require)
     (process-goog-import)
     (ns-macro)
+    (ns-macro-with-macros)
     (process-reload)
     (process-reload-all)))
 


### PR DESCRIPTION
In this PR I don't use `foo.bar`... and the tests are passing... the order is the same, I only changed the file name and the namespace name from `foo.bar` to `foo.test`, and it works.

The previous one was failing and it seems [this](https://github.com/clojure/clojurescript/blob/e33e554331c555952079d284d822cf16219ac56a/src/main/cljs/cljs/js.cljs#L415) is the error that was thrown... but I wonder because in the same file (js.cljs) there is something [suspicious](https://github.com/clojure/clojurescript/blob/e33e554331c555952079d284d822cf16219ac56a/src/main/cljs/cljs/js.cljs#L884)..

Anyway this PR is my definitive, if you want to investigate feel free to do it :game_die:  
