### PR TITLE
Test for require-macros (except :as). Closes #64.

### DIFF
--- a/dev-resources/private/test/src/clj/foo/bar.cljc
+++ b/dev-resources/private/test/src/clj/foo/bar.cljc
@@ -1,1 +1,0 @@
-(ns foo.bar)

--- a/dev-resources/private/test/src/clj/foo/bar/baz.clj
+++ b/dev-resources/private/test/src/clj/foo/bar/baz.clj
@@ -1,0 +1,5 @@
+(ns foo.bar.baz)
+
+(defmacro mul-baz
+  [a b]
+  `(* ~a ~b))

--- a/dev-resources/private/test/src/clj/foo/bar/quux.clj
+++ b/dev-resources/private/test/src/clj/foo/bar/quux.clj
@@ -1,0 +1,5 @@
+(ns foo.bar.quux)
+
+(defmacro mul-quux
+  [a b]
+  `(* ~a ~b))

--- a/dev-resources/private/test/src/clj/foo/baz.clj
+++ b/dev-resources/private/test/src/clj/foo/baz.clj
@@ -1,1 +1,0 @@
-(ns foo.baz)

--- a/src/cljs/replumb/repl.cljs
+++ b/src/cljs/replumb/repl.cljs
@@ -806,10 +806,10 @@
 (defn reset-env!
   "It does the following (in order):
 
-  1. remove the input namespaces from the compiler environment
-  2. set *e to nil
+  1. in-ns to cljs.user
+  2. remove the input namespaces from the compiler environment
   3. reset the last warning
-  4. in-ns to cljs.user
+  4. set *e to nil
 
   It accepts a sequence of symbols or strings."
   ([]
@@ -817,9 +817,9 @@
   ([namespaces]
    (read-eval-call {} identity "(in-ns 'cljs.user)")
    (doseq [ns namespaces]
-     (purge-ns! st (symbol ns)))
+     (purge-ns! st (symbol ns))
+     (purge-ns! st (symbol (str ns "$macros"))))
    (if (seq @cljs.js/*loaded*)
      (throw (ex-info (str "The cljs.js/*loaded* atom still contains " @cljs.js/*loaded* " - make sure you purge dependent namespaces.") ex-info-data)))
-   (assert (empty? @cljs.js/*loaded*))
    (reset-last-warning!)
    (read-eval-call {} identity "(set! *e nil)")))

--- a/test/cljs/replumb/repl_test.cljs
+++ b/test/cljs/replumb/repl_test.cljs
@@ -390,7 +390,7 @@ select-keys
       (is (success? res) "Executing (foo.core/hello ..) as function should succeed")
       (is (valid-eval-result? out) "Executing (foo.core/hello ..) hello ..) as function should have a valid result")
       (is (= "6" out) "Executing (foo.core/hello ..) hello ..) as function shoud return 6")
-      (repl/reset-env! '[foo.core another.ns foo.core$macros])))
+      (repl/reset-env! '[foo.core another.ns])))
 
   (deftest tagged-literals
     ;; AR - Don't need to test more as ClojureScript already has extensive tests on this

--- a/test/cljs/replumb/repl_test.cljs
+++ b/test/cljs/replumb/repl_test.cljs
@@ -363,6 +363,7 @@ select-keys
       (is (valid-eval-result? out) "(defmacro hello ..) should have a valid result")
       (is (= "true" out) "(defmacro hello ..) shoud return true")
       (repl/reset-env!))
+
     (let [res (do (read-eval-call "(defmacro hello [x] `(inc ~x))")
                   (read-eval-call "(hello nil nil 13)"))
           out (unwrap-result res)]
@@ -389,7 +390,7 @@ select-keys
       (is (success? res) "Executing (foo.core/hello ..) as function should succeed")
       (is (valid-eval-result? out) "Executing (foo.core/hello ..) hello ..) as function should have a valid result")
       (is (= "6" out) "Executing (foo.core/hello ..) hello ..) as function shoud return 6")
-      (repl/reset-env! '[foo.core])))
+      (repl/reset-env! '[foo.core another.ns foo.core$macros])))
 
   (deftest tagged-literals
     ;; AR - Don't need to test more as ClojureScript already has extensive tests on this

--- a/test/node/replumb/require_node_test.cljs
+++ b/test/node/replumb/require_node_test.cljs
@@ -324,7 +324,7 @@ trim-newline
       (is (success? res) "(ns my.namespace (:require-macros ...)) and (foo.bar.baz/mul-baz 2 2) should succeed")
       (is (valid-eval-result? out) "(ns my.namespace (:require-macros ...)) and (foo.bar.bar/mul-baz 2 2) should be a valid result.")
       (is (= "4" out) "(foo.bar.bar/mul-baz 2 2) should be 4")
-      (repl/reset-env! '[my.namespace foo.bar.baz foo.bar.baz$macros]))
+      (repl/reset-env! '[my.namespace foo.bar.baz]))
 
     ;; only quux.clj file and namespace
     (let [res (do (read-eval-call "(ns my.namespace (:require-macros [foo.bar.quux]))")
@@ -333,7 +333,7 @@ trim-newline
       (is (success? res) "(ns my.namespace (:require-macros ...)) and (foo.bar.quux/mul-quux 2 2) should succeed")
       (is (valid-eval-result? out) "(ns my.namespace (:require-macros ...)) and (foo.bar.quux/mul-quux 2 2) should be a valid result.")
       (is (= "4" out) "(foo.quux/mul-quux 2 2) should be 4")
-      (repl/reset-env! '[my.namespace foo.bar.quux foo.bar.quux$macros]))
+      (repl/reset-env! '[my.namespace foo.bar.quux]))
 
     (let [res (do (read-eval-call "(ns my.namespace (:require-macros [foo.bar.baz :refer [mul-baz]]))")
                   (read-eval-call "(mul-baz 3 3)"))
@@ -341,7 +341,7 @@ trim-newline
       (is (success? res) "(ns my.namespace (:require-macros ... :refer ...)) and (mul-baz 3 3) should succeed")
       (is (valid-eval-result? out) "(ns my.namespace (:require-macros ...:refer...)) and (mul-baz 3 3) should be a valid result.")
       (is (= "9" out) "(mul-baz 3 3) should be 9")
-      (repl/reset-env! '[my.namespace foo.bar.baz foo.bar.baz$macros]))
+      (repl/reset-env! '[my.namespace foo.bar.baz]))
 
     (let [res (do (read-eval-call "(ns my.namespace (:require-macros [foo.bar.quux :refer [mul-quux]]))")
                   (read-eval-call "(mul-quux 3 3)"))
@@ -349,7 +349,7 @@ trim-newline
       (is (success? res) "(ns my.namespace (:require-macros ... :refer ...)) and (mul-quux 3 3) should succeed")
       (is (valid-eval-result? out) "(ns my.namespace (:require-macros ...:refer...)) and (mul-quux 3 3) should be a valid result.")
       (is (= "9" out) "(mul-quux 3 3) should be 9")
-      (repl/reset-env! '[my.namespace foo.bar.quux foo.bar.quux$macros]))
+      (repl/reset-env! '[my.namespace foo.bar.quux]))
 
     (let [res (do (read-eval-call "(ns my.namespace (:use-macros [foo.bar.baz :only [mul-baz]]))")
                   (read-eval-call "(mul-baz 5 5)"))
@@ -357,7 +357,7 @@ trim-newline
       (is (success? res) "(ns my.namespace (:use-macros ...)) and (mul-baz 5 5) should succeed")
       (is (valid-eval-result? out) "(ns my.namespace (:use-macros ...)) and (mul-baz 5 5) should be a valid result.")
       (is (= "25" out) "(mul-baz 5 5) should be 25")
-      (repl/reset-env! '[my.namespace foo.bar.baz foo.bar.baz$macros]))
+      (repl/reset-env! '[my.namespace foo.bar.baz]))
 
     (let [res (do (read-eval-call "(ns my.namespace (:use-macros [foo.bar.quux :only [mul-quux]]))")
                   (read-eval-call "(mul-quux 5 5)"))
@@ -365,7 +365,7 @@ trim-newline
       (is (success? res) "(ns my.namespace (:use-macros ...)) and (mul-quux 5 5) should succeed")
       (is (valid-eval-result? out) "(ns my.namespace (:use-macros ...)) and (mul-quux 5 5) should be a valid result.")
       (is (= "25" out) "(mul-quux 25) should be 25")
-      (repl/reset-env! '[my.namespace foo.bar.quux foo.bar.quux$macros])))
+      (repl/reset-env! '[my.namespace foo.bar.quux])))
 
   (deftest process-reload
     (let [alterable-core-path "dev-resources/private/test/src/cljs/alterable/core.cljs"

--- a/test/node/replumb/source_node_test.cljs
+++ b/test/node/replumb/source_node_test.cljs
@@ -105,7 +105,7 @@
       (is (success? res) "(source foo.bar.baz/a) should succeed.")
       (is (valid-eval-result? source-string) "(source foo.bar.baz/a) should be a valid result")
       (is (= expected source-string) "(source foo.bar.baz/a) should return valid source")
-      (repl/reset-env! ['foo.bar.baz]))
+      (repl/reset-env! '[foo.bar.baz]))
 
     ;; https://github.com/ScalaConsultants/replumb/issues/86
     (let [res (do (read-eval-call "(require '[foo.bar.baz :as baz])")
@@ -115,7 +115,7 @@
       (is (success? res) "(require '[foo.bar.baz :as baz]) and (source baz/a) should succeed.")
       (is (valid-eval-result? source-string) "(require '[foo.bar.baz :as baz]) and (source baz/a) should be a valid result")
       (is (= expected source-string) "(require '[foo.bar.baz :as baz]) and (source baz/a) should return valid source")
-      (repl/reset-env! ['foo.bar.baz])))
+      (repl/reset-env! '[foo.bar.baz])))
 
   ;; see "RUNNING TESTS" section for explanation of `test-ns-hook` special function
   ;; https://clojure.github.io/clojure/clojure.test-api.html


### PR DESCRIPTION
You can comment and then merge this. I will use https://github.com/ScalaConsultants/replumb/pull/97 for another issue (test macros with require `include-macros` and `refer-macros`)
