### PR TITLE
Added tests for cljc files, include-macros and refer-macros. Closes #101.

### DIFF
--- a/dev-resources/private/test/src/cljc/foo/bar/core.cljc
+++ b/dev-resources/private/test/src/cljc/foo/bar/core.cljc
@@ -1,0 +1,15 @@
+(ns foo.bar.core
+  (#?(:clj  :require
+      :cljs :require-macros) [foo.bar.macros]))
+
+(defmacro mul-core
+  [a b]
+  `(* ~a ~b))
+
+(defn str->int [s]
+  #?(:clj  (Integer/parseInt s)
+     :cljs (js/parseInt s)))
+
+(defn add-five [s]
+  (+ (str->int s)
+     (foo.bar.macros/str->int "5")))

--- a/dev-resources/private/test/src/cljc/foo/bar/macros.cljc
+++ b/dev-resources/private/test/src/cljc/foo/bar/macros.cljc
@@ -1,0 +1,5 @@
+(ns foo.bar.macros)
+
+(defmacro str->int [s]
+  #?(:clj  (Integer/parseInt s)
+     :cljs (js/parseInt s)))

--- a/dev-resources/private/test/src/cljc/foo/bar/self.cljc
+++ b/dev-resources/private/test/src/cljc/foo/bar/self.cljc
@@ -1,0 +1,12 @@
+(ns foo.bar.self
+  #?(:cljs (:require-macros [foo.bar.self :refer [add]])))
+
+#?(:clj 
+  (defmacro add
+    [a b]
+    `(+ ~a ~b)))
+
+#?(:cljs
+  (defn sum
+    [a b]
+    (add a b)))

--- a/scripts/node-repl.sh
+++ b/scripts/node-repl.sh
@@ -2,4 +2,4 @@
 
 # For convenience you can pass --verbose here and it will be forwarded to the repl
 node dev-resources/private/node/compiled/nodejs-repl.js $1 \
-     dev-resources/private/node/compiled/out:dev-resources/private/test/src/cljs:dev-resources/private/test/src/clj
+     dev-resources/private/node/compiled/out:dev-resources/private/test/src/cljs:dev-resources/private/test/src/clj:dev-resources/private/test/src/cljc


### PR DESCRIPTION
Added tests for possibly every way to require macros. Unfortunately there is still the issue with the order of tests but I will open a separate issue for that. Of course it's not only a problem with tests because it can be easily replicated in the repl. 

Very probably is related to the fact the the `1.7.170` contains bugs in these features, which have been partially solved in `1.7.202`.

So here should be the complete suit of tests.
