### PR TITLE
Improve (source macro) code path and (almost) fixes #85

### DIFF
--- a/test/cljs/replumb/load_test.cljs
+++ b/test/cljs/replumb/load_test.cljs
@@ -1,23 +1,33 @@
-(ns ^:figwheel-load replumb.load-test
+(ns replumb.load-test
   (:require [cljs.test :refer-macros [deftest is]]
-            [clojure.string :as string]
-            [replumb.load :refer [file-paths-to-try]]))
+            [replumb.load :refer [file-paths-for-load-fn file-paths]]))
 
-(deftest files
-  (is (empty? (file-paths-to-try [] true "temp")) "No files should be tried with empty source path and if :macros true")
-  (is (empty? (file-paths-to-try [] false "temp")) "No files should be tried with empty source path and if :macros false")
+(deftest paths-without-ext
+  (is (empty? (file-paths-for-load-fn [] true "temp")) "If empty src-paths and :macros true, file-paths-for-load-fn should return empty vector")
+  (is (empty? (file-paths-for-load-fn [] false "temp")) "If empty src-paths and :macros false, file-paths-for-load-fn should return empty vector")
+
   (let [src-paths ["src1/foo" "src2/" "src3/foo/bar"]
         file "core"
         cljs-files (map #(str % (when-not (= "/" (last %)) "/") file ".cljs") src-paths)
         cljc-files (map #(str % (when-not (= "/" (last %)) "/") file ".cljc") src-paths)
         clj-files (map #(str % (when-not (= "/" (last %)) "/") file ".clj") src-paths)
         js-files (map #(str % (when-not (= "/" (last %)) "/") file ".js") src-paths)]
-    (let [files (into [] (file-paths-to-try src-paths false file))]
-      (is (= 9 (count files)) "With 3 paths 9 files should be tried if :macros false")
-      (is (= cljs-files (subvec files 0 3)) "Try .cljs files first if :macros false")
-      (is (= cljc-files (subvec files 3 6)) "Try .cljc files second if :macros false")
-      (is (= js-files (subvec files 6)) "Try .js files third if :macros false"))
-    (let [files (into [] (file-paths-to-try src-paths true file))]
-      (is (= 6 (count files)) "With 3 paths 6 files should be tried if :macros true")
-      (is (= clj-files (subvec files 0 3)) "Try .clj files first if :macros true")
-      (is (= cljc-files (subvec files 3)) "Try .cljc files second if :macros true"))))
+    (let [files (into [] (file-paths-for-load-fn src-paths false file))]
+      (is (= 9 (count files)) "With 3 paths and :macros false, file-paths-for-load-fn should try 9 files")
+      (is (= cljs-files (subvec files 0 3)) "When :macros false, file-paths-for-load-fn should try .cljs files first")
+      (is (= cljc-files (subvec files 3 6)) "When :macros false, file-paths-for-load-fn should try .cljc files second")
+      (is (= js-files (subvec files 6)) "When :macros false, file-paths-for-load-fn should try .js files third"))
+
+    (let [files (into [] (file-paths-for-load-fn src-paths true file))]
+      (is (= 6 (count files)) "With 3 paths and :macros true, file-paths-for-load-fn should try 6 files")
+      (is (= clj-files (subvec files 0 3)) "When :macros true, file-paths-for-load-fn should try .clj files first")
+      (is (= cljc-files (subvec files 3)) "When :macros true, file-paths-for-load-fn should try .cljc files second"))))
+
+(deftest paths-with-ext
+  (is (empty? (file-paths [] "temp.clj")) "If src-paths is empty, file-paths-for-load-fn should return empty vector")
+
+  (let [src-paths ["src1/foo" "src2/" "src3/foo/bar"]
+        file "baz.clj"
+        expected-path (map #(str % (when-not (= "/" (last %)) "/") file) src-paths)
+        files (into [] (file-paths src-paths file))]
+    (is (= expected-path files) "The fn file-paths (remember it does not add extension), should return the expected 3 files")))

--- a/test/node/replumb/source_node_test.cljs
+++ b/test/node/replumb/source_node_test.cljs
@@ -17,7 +17,7 @@
       reset-env! (partial repl/reset-env! target-opts)
       read-eval-call (partial repl/read-eval-call target-opts validated-echo-cb)]
 
-  (deftest source-in-cljs-core
+  (deftest source-in-cljs-core-fns
     (let [res (read-eval-call "(source max)")
           source-string (unwrap-result res)
           expected "(defn ^number max
@@ -47,6 +47,24 @@
       (is (success? res) "(source not-existing) should succeed.")
       (is (valid-eval-result? source-string) "(source not-existing) should be a valid result")
       (is (= "nil" source-string) "(source not-existing) should return nil")
+      (reset-env!)))
+
+  (deftest source-in-cljs-core-macros
+    ;; AR - when bundling and https://github.com/ScalaConsultants/replumb/issues/69
+    ;; will be hacked together, this will work. The reason is that we need
+    ;; clojure/core.clj on the source path.
+    ;; (let [res (read-eval-call "(source when)")
+        ;; source-string (unwrap-result res)]
+      ;; (is (success? res) "(source when) should succeed.")
+      ;; (is (valid-eval-result? source-string) "(source when) should be a valid result")
+      ;; (is (re-find #"core/defmacro when" source-string) "(source when) does not correspond to correct source")
+      ;; (reset-env!))
+
+    (let [res (read-eval-call "(source or)")
+          source-string (unwrap-result res)]
+      (is (success? res) "(source or) should succeed.")
+      (is (valid-eval-result? source-string) "(source or) should be a valid result")
+      (is (re-find #"core/defmacro or" source-string) "(source or) should return correct source")
       (reset-env!)))
 
   (deftest source-in-non-core-ns
@@ -122,7 +140,8 @@
   ;; https://clojure.github.io/clojure/clojure.test-api.html
   (defn test-ns-hook []
     (repl/force-init!)
-    (source-in-cljs-core)
+    (source-in-cljs-core-fns)
+    (source-in-cljs-core-macros)
     (source-in-non-core-ns)
     (source-in-custom-ns)))
 


### PR DESCRIPTION
This almost fixes the problem with `(source macro-sym)` but does not actually solve everything.
It looks like there is no correspondence with the AST info and the actual source file in some cases (like `(source when)`).

I will file a separate issue.

In the meantime, `or` (and others) works. I will need to fix some tests it seems.
