### PR TITLE
Handle doc calls for &, catch, and finally

### DIFF
--- a/src/cljs/replumb/repl.cljs
+++ b/src/cljs/replumb/repl.cljs
@@ -540,6 +540,12 @@
                                  (common/wrap-error error)
                                  (common/wrap-success nil))))))))
 
+(defn doc-map-special-symbols
+  [sym]
+  (get '{&       fn
+         catch   try
+         finally try} sym sym))
+
 (defn process-doc
   [opts cb data sym]
   (call-back! (merge opts {:no-pr-str-on-value true})
@@ -547,11 +553,12 @@
               data
               (common/wrap-success
                (with-out-str
-                 (cond
-                   (docs/special-doc-map sym) (repl/print-doc (docs/special-doc sym))
-                   (docs/repl-special-doc-map sym) (repl/print-doc (docs/repl-special-doc sym))
-                   (ast/namespace @st sym) (repl/print-doc (select-keys (ast/namespace @st sym) [:name :doc]))
-                   :else (repl/print-doc (get-var opts (empty-analyzer-env) sym)))))))
+                 (let [sym (doc-map-special-symbols sym)]
+                   (cond
+                     (docs/special-doc-map sym) (repl/print-doc (docs/special-doc sym))
+                     (docs/repl-special-doc-map sym) (repl/print-doc (docs/repl-special-doc sym))
+                     (ast/namespace @st sym) (repl/print-doc (select-keys (ast/namespace @st sym) [:name :doc]))
+                     :else (repl/print-doc (get-var opts (empty-analyzer-env) sym))))))))
 
 (defn process-pst
   [opts cb data expr]


### PR DESCRIPTION
The standard ClojureScript REPL handles doc calls for & by mapping it
to fn, and for catch and finally by mapping it to try
