### PR TITLE
Fix for goog.dependencies_ call when :simple

### DIFF
--- a/dev-resources/private/browser/index.html
+++ b/dev-resources/private/browser/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <link href="styles/console.css" rel="stylesheet" type="text/css">
+
+    <div id="app"></div>
+
+    <script src="js/compiled/replumb-repl.js"></script>
+    <script src="js/simple/compiled/replumb-repl.js"></script>
+    <script>replumb_repl.core.main();</script>
+  </body>
+</html>

--- a/dev-resources/private/browser/styles/console.css
+++ b/dev-resources/private/browser/styles/console.css
@@ -1,0 +1,71 @@
+.console-container {
+    position: relative;
+    height: 220px;
+    border-radius: 5px;
+    -moz-border-radius: 5px;
+    border: 1px solid #d5ceb4;
+}
+
+/* The inner console element. */
+/* .jqconsole { */
+/*   background-color: black;; */
+/* } */
+
+.jqconsole-prompt {
+  color: black;
+}
+
+.jqconsole-old-prompt {
+   color: #9A7C7D;
+   font-weight: normal;
+}
+
+.jqconsole-output {
+  font-weight: lighter;
+  font-family: monospace;
+  color: dark-grey;
+}
+
+.jqconsole-return {
+  font-size: small;
+  font-weight: lighter;
+  font-family: monospace;
+  color: #CB2531;
+}
+
+.jqconsole-error {
+   font-size: small;
+   font-weight: lighter;
+   font-family: monospace;
+   color: #E6959B;
+}
+
+/* The cursor. */
+.jqconsole-cursor {
+   font-weight: normal;
+   font-family: monospace;
+   background-color: #CB2531;
+}
+
+/* The cursor color when the console looses focus. */
+.jqconsole-blurred .jqconsole-cursor {
+  font-weight: normal;
+  font-family: monospace;
+  background-color: #E6959B;
+}
+
+/*.brace {
+/*   color: #00FFFF; */
+/* } */
+/* .paren { */
+/*   color: #FF00FF; */
+/* } */
+/* .bracket { */
+/*   color: #FFFF00; */
+/* } */
+/* .dquote { */
+/*   color: #FF8888; */
+/* } */
+/* .jqconsole-composition { */
+/*   background-color: red; */
+/* } */

--- a/project.clj
+++ b/project.clj
@@ -11,11 +11,18 @@
   :plugins [[lein-cljsbuild "1.1.1"]
             [lein-codox "0.9.0"]]
 
-  :clean-targets ^{:protect false} ["dev-resources/public/js/compiled" "dev-resources/private/test/browser/compiled"
-                                    "dev-resources/private/test/node/compiled" "dev-resources/private/node"
+  :clean-targets ^{:protect false} ["dev-resources/public/js/compiled"                 ;; dev
+                                    "dev-resources/private/browser/js/compiled"        ;; browser-repl
+                                    "dev-resources/private/browser/js/simple/compiled" ;; browser-repl-simple
+                                    "dev-resources/private/node/js/compiled"           ;; node-repl
+                                    "dev-resources/private/test/browser/compiled"      ;; browser-test, browser-simple-test
+                                    "dev-resources/private/test/node/compiled"         ;; node-test, node-simple-test
+                                    "resources/public/js/compiled"                     ;; min
                                     "out" :target-path]
   :source-paths ["src/cljs"]
   :hooks [leiningen.cljsbuild]
+  :min-lein-version "2.0.0"
+  :jvm-opts ^:replace ["-XX:+TieredCompilation" "-XX:TieredStopAtLevel=1" "-Xverify:none"]
 
   :cljsbuild {:builds [{:id "dev"
                         :source-paths ["src/cljs" "src/browser" "repl-demo/browser/cljs"]
@@ -28,6 +35,37 @@
                                    :asset-path "js/compiled/out"
                                    :source-map-timestamp true
                                    :static-fns true}}
+                       {:id "browser-repl"
+                        :source-paths ["src/cljs" "src/browser" "repl-demo/browser/cljs"]
+                        :compiler {:optimizations :none
+                                   :main replumb-repl.core
+                                   :output-to "dev-resources/private/browser/js/compiled/replumb-repl.js"
+                                   :output-dir "dev-resources/private/browser/js/compiled/out"
+                                   :asset-path "js/compiled/out"
+                                   :source-map-timestamp true
+                                   :static-fns true
+                                   :parallel-build true}}
+                       {:id "browser-repl-simple"
+                        :source-paths ["src/cljs" "src/browser" "repl-demo/browser/cljs"]
+                        :compiler {:optimizations :simple
+                                   :main replumb-repl.core
+                                   :output-to "dev-resources/private/browser/js/simple/compiled/replumb-repl.js"
+                                   :output-dir "dev-resources/private/browser/js/simple/compiled/out"
+                                   :asset-path "js/simple/compiled/out"
+                                   :source-map "dev-resources/private/browser/js/simple/compiled/replumb-repl.js.map"
+                                   :source-map-timestamp true
+                                   :static-fns true
+                                   :parallel-build true}}
+                       {:id "node-repl"
+                        :source-paths ["src/cljs" "src/node" "repl-demo/node/cljs"]
+                        :compiler {:target :nodejs
+                                   :optimizations :none
+                                   :main nodejs-repl.core
+                                   :output-to "dev-resources/private/node/js/compiled/nodejs-repl.js"
+                                   :output-dir "dev-resources/private/node/js/compiled/out"
+                                   :asset-path "js/compiled/out"
+                                   :static-fns true
+                                   :parallel-build true}}
                        {:id "browser-test"
                         :source-paths ["src/cljs" "test/cljs" "test/browser"]
                         :compiler {:optimizations :none
@@ -35,7 +73,17 @@
                                    :output-to "dev-resources/private/test/browser/compiled/browser-test.js"
                                    :output-dir "dev-resources/private/test/browser/compiled/out"
                                    :asset-path "dev-resources/private/test/browser/compiled/out"
-                                   :static-fns true}}
+                                   :static-fns true
+                                   :parallel-build true}}
+                       #_{:id "browser-simple-test"
+                          :source-paths ["src/cljs" "test/cljs" "test/browser"]
+                          :compiler {:optimizations :simple
+                                     :main launcher.runner
+                                     :output-to "dev-resources/private/test/browser/compiled/browser-test.js"
+                                     :output-dir "dev-resources/private/test/browser/compiled/out"
+                                     :asset-path "dev-resources/private/test/browser/compiled/out"
+                                     :static-fns true
+                                     :parallel-build true}}
                        {:id "node-test"
                         :source-paths ["src/cljs" "src/node" "test/cljs" "test/node"]
                         :compiler {:target :nodejs
@@ -44,24 +92,27 @@
                                    :output-to "dev-resources/private/test/node/compiled/nodejs-test.js"
                                    :output-dir "dev-resources/private/test/node/compiled/out"
                                    :asset-path "dev-resources/private/test/node/compiled/out"
-                                   :static-fns true}}
-                       {:id "node-repl"
-                        :source-paths ["src/cljs" "src/node" "repl-demo/node/cljs"]
-                        :compiler {:target :nodejs
-                                   :optimizations :none
-                                   :main nodejs-repl.core
-                                   :output-to "dev-resources/private/node/compiled/nodejs-repl.js"
-                                   :output-dir "dev-resources/private/node/compiled/out"
-                                   :asset-path "dev-resources/private/node/compiled/out"
-                                   :static-fns true}}
+                                   :static-fns true
+                                   :parallel-build true}}
+                       #_{:id "node-simple-test"
+                          :source-paths ["src/cljs" "src/node" "test/cljs" "test/node"]
+                          :compiler {:target :nodejs
+                                     :optimizations :simple
+                                     :main launcher.runner
+                                     :output-to "dev-resources/private/test/node/compiled/nodejs-test.js"
+                                     :output-dir "dev-resources/private/test/node/compiled/out"
+                                     :asset-path "dev-resources/private/test/node/compiled/out"
+                                     :static-fns true
+                                     :parallel-build true}}
                        {:id "min"
                         :source-paths ["src/cljs"]
                         :compiler { ;; :main cljs-browser-repl.core ;; https://github.com/emezeske/lein-cljsbuild/issues/420
-                                   :output-to "dev-resources/public/js/compiled/replumb-repl.js"
+                                   :output-to "resources/public/js/compiled/replumb-repl.js"
                                    :optimizations :simple
                                    :pretty-print false
                                    :elide-asserts true
-                                   :static-fns true}}]}
+                                   :static-fns true
+                                   :parallel-build true}}]}
   ;; :figwheel {:repl false}
 
   :prep-tasks ["codox"]
@@ -73,9 +124,14 @@
 
   :aliases {"fig-dev" ^{:doc "Start figwheel with dev profile."} ["figwheel" "dev"]
             "fig-dev*" ^{:doc "Clean and start figwheel with dev profile"} ["do" "clean" ["figwheel" "dev"]]
+
+            "node-repl" ^{:doc "Clean, build and launch the node demo repl. Node.js must be installed."} ["do" "clean" ["cljsbuild" "once" "node-repl"] ["shell" "scripts/node-repl.sh"]]
+            "browser-repl" ^{:doc "Clean, build and launch the browser demo repl."} ["do" "clean" ["cljsbuild" "once" "browser-repl"] ["shell" "scripts/browser-repl.sh" "dev-resources/private/browser"]]
+            "browser-repl-simple" ^{:doc "Clean, build and launch the browser demo repl."} ["do" "clean" ["cljsbuild" "once" "browser-repl-simple"] ["shell" "scripts/browser-repl.sh"]]
+
             "minify" ^{:doc "Compile sources minified for production."} ["cljsbuild" "once" "min"]
             "minify*" ^{:doc "Clean and compile sources minified for production."} ["do" "clean" ["cljsbuild" "once" "min"]]
-            "node-repl" ^{:doc "Clean, build and launch the node demo repl. Node.js (must be installed)."} ["do" "clean" ["cljsbuild" "once" "node-repl"] ["shell" "scripts/node-repl.sh"]]
+
             "test-phantom" ^{:doc "Execute once unit tests with PhantomJS (must be installed)."} ["doo" "phantom" "browser-test" "once"]
             "test-phantom*" ^{:doc "Clean and execute once unit tests with PhantomJS (must be installed)."} ["do" "clean" ["doo" "phantom" "browser-test" "once"]]
             "auto-phantom" ^{:doc "Clean and execute automatic unit tests with PhantomJS (must be installed)."} ["do" "clean" ["doo" "phantom" "browser-test" "auto"]]

--- a/project.clj
+++ b/project.clj
@@ -153,5 +153,5 @@
                                   [cljsjs/jqconsole "2.13.1-0"]
                                   [reagent "0.5.1"]]
                    :plugins [[lein-doo "0.1.6"]
-                             [lein-figwheel "0.5.0-2" :exclusions [cider/cider-nrepl]]
+                             [lein-figwheel "0.5.0-6" :exclusions [cider/cider-nrepl]]
                              [lein-shell "0.4.2"]]}})

--- a/scripts/browser-repl.sh
+++ b/scripts/browser-repl.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+echo "Now you can connect to http://localhost:9090"
+cd dev-resources/private/browser
+python -m SimpleHTTPServer 9090

--- a/src/cljs/replumb/repl.cljs
+++ b/src/cljs/replumb/repl.cljs
@@ -276,7 +276,7 @@
        ;; (it's the case when the "js" file is in the compilation set)
        ;; then also check in the user provided :foreign-libs option (for libraries not known
        ;; at compile time - we need to indicate the ns->file mapping)
-       :else (let [path (or (file-path-from-goog-dependencies (str name))
+       :else (let [path (or (when js/goog.DEPENDENCIES_ENABLED (file-path-from-goog-dependencies (str name)))
                             (file-path-from-foreign-libs (str name) foreign-libs)
                             path)
                    args [verbose (load/file-paths-for-load-fn src-paths macros path) read-file-fn! cb]

--- a/test/browser/launcher/runner.cljs
+++ b/test/browser/launcher/runner.cljs
@@ -8,4 +8,8 @@
             replumb.require-browser-test
             replumb.source-browser-test))
 
+;; Or doo will exit with an error, see:
+;; https://github.com/bensu/doo/issues/83#issuecomment-165498172
+(set! (.-error js/console) (fn [x] (.log js/console x)))
+
 (doo-all-tests #"^replumb.*-test")

--- a/test/node/replumb/require_node_test.cljs
+++ b/test/node/replumb/require_node_test.cljs
@@ -18,8 +18,8 @@
 (let [src-paths ["dev-resources/private/test/node/compiled/out"
                  "dev-resources/private/test/src/cljs"
                  "dev-resources/private/test/src/clj"
-                  "dev-resources/private/test/src/cljc"
-                  "dev-resources/private/test/src/js"]
+                 "dev-resources/private/test/src/cljc"
+                 "dev-resources/private/test/src/js"]
       target-opts (nodejs-options src-paths io/read-file!)
       validated-echo-cb (partial repl/validated-call-back! target-opts echo-callback)
       reset-env! (partial repl/reset-env! target-opts)


### PR DESCRIPTION
Introduces a when before using `goog.dependencies_`

Based on the reference at the bottom, `goog.dependencies_` is available only if `goog.COMPILED` is not true (according to David Nolen not available then for `:simple` and `:advanced`). In general the use of goog.dependencies_ is not advisable as it is an implementation detail of the Google Closure Library.

The best option for including a lib is the `:foreign-libs` to `read-eval-call`.

Reference code:
https://google.github.io/closure-library/api/source/closure/goog/base.js.src.html#l795
