### PR TITLE
Better log

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ with the evaluation result.
 The first parameter is a map of configuration options, currently
 supporting:
 
-* `:verbose` will enable the the evaluation logging, defaults to false
+* `:verbose` will enable the evaluation logging, defaults to false.
+To customize how to print, use `(set! *print-fn* (fn [& args] ...)`
+
 * `:warning-as-error` will consider a compiler warning as error
 * `:target` `:nodejs` and `:browser` supported, the latter is used if
 missing

--- a/project.clj
+++ b/project.clj
@@ -75,7 +75,7 @@
                                    :asset-path "dev-resources/private/test/browser/compiled/out"
                                    :static-fns true
                                    :parallel-build true}}
-                       #_{:id "browser-simple-test"
+                       #_{:id "browser-test-simple"
                           :source-paths ["src/cljs" "test/cljs" "test/browser"]
                           :compiler {:optimizations :simple
                                      :main launcher.runner
@@ -94,7 +94,7 @@
                                    :asset-path "dev-resources/private/test/node/compiled/out"
                                    :static-fns true
                                    :parallel-build true}}
-                       #_{:id "node-simple-test"
+                       #_{:id "node-test-simple"
                           :source-paths ["src/cljs" "src/node" "test/cljs" "test/node"]
                           :compiler {:target :nodejs
                                      :optimizations :simple

--- a/repl-demo/browser/cljs/replumb_repl/console/cljs.cljs
+++ b/repl-demo/browser/cljs/replumb_repl/console/cljs.cljs
@@ -33,7 +33,8 @@
    (fn []
      (let [repl-opts (merge (replumb/browser-options ["/src/cljs" "/js/compiled/out"]
                                                      io/fetch-file!)
-                            {:warning-as-error true})
+                            {:warning-as-error true
+                             :verbose true})
            jqconsole (console/new-jqconsole "#cljs-console"
                                             (merge {:prompt-label (replumb/get-prompt)
                                                     :disable-auto-focus true}

--- a/repl-demo/browser/cljs/replumb_repl/core.cljs
+++ b/repl-demo/browser/cljs/replumb_repl/core.cljs
@@ -8,6 +8,9 @@
 
 (enable-console-print!)
 
+(set! *print-fn* (fn [& args]
+                   (.apply (.-debug js/console) js/console (into-array args))))
+
 (defn page []
   [:div
    [cljs/cljs-component]])

--- a/src/cljs/replumb/common.cljs
+++ b/src/cljs/replumb/common.cljs
@@ -104,9 +104,15 @@
     (into opts new-fn-entries)))
 
 (defn debug-prn
+  "The function used by replumb for logging. It simply calls println for
+  now so you that client code can set *print-fn* to customize the
+  behavior, for example the following marks traces as DEBUG:
+
+  (set! *print-fn*
+    (fn [& args]
+      (.apply (.-debug js/console) js/console (into-array args))))"
   [& args]
-  (binding [cljs.core/*print-fn* cljs.core/*print-err-fn*]
-    (apply println args)))
+  (apply println args))
 
 (defn normalize-path
   "Adds a / if missing at the end of the path."

--- a/src/cljs/replumb/core.cljs
+++ b/src/cljs/replumb/core.cljs
@@ -10,7 +10,9 @@
   The first parameter is a map of configuration options, currently
   supporting:
 
-  * `:verbose` will enable the the evaluation logging, defaults to false
+  * `:verbose` will enable the the evaluation logging, defaults to false.
+  To customize how to print, use `(set! *print-fn* (fn [& args] ...)`
+
   * `:warning-as-error` will consider a compiler warning as error
   * `:target` `:nodejs` and `:browser` supported, the latter is used if
   missing

--- a/src/cljs/replumb/repl.cljs
+++ b/src/cljs/replumb/repl.cljs
@@ -467,7 +467,7 @@
 
   Call-back! supports the following opts:
 
-  * :verbose will enable the the evaluation logging, defaults to false.
+  * :verbose will enable the evaluation logging, defaults to false.
   * :no-pr-str-on-value avoids wrapping successful value in a pr-str
   * :warning-as-error will consider a warning like an error
 
@@ -903,14 +903,14 @@
   file is found). It is mutually exclusive with :load-fn! and will be
   ignored in case both are present
 
-  * `:write-file-fn!` a synchronous 2-arity function with signature
-  `[file-path data]` that accepts a file-path and data to write.
+  * :write-file-fn! a synchronous 2-arity function with signature
+  [file-path data] that accepts a file-path and data to write.
 
   * :src-paths - a vector of paths containing source files
 
   * :cache - a map containing two optional values: the first, :path, indicates
   the path of the cached files. The second, :src-paths-lookup?, indicates
-  if look for cached files in :src-paths. If both present, `:path` will have
+  if look for cached files in :src-paths. If both present, :path will have
   the priority but both will be inspected.
 
   * :no-pr-str-on-value - in case of :success? avoid converting the
@@ -919,7 +919,7 @@
   * :context - indicates the evaluation context that will be passed to
   cljs/eval-str. Defaults to :expr.
 
-  * `:foreign-libs` - a way to include foreign libraries. The format is analogous
+  * :foreign-libs - a way to include foreign libraries. The format is analogous
   to the compiler option. For more info visit https://github.com/clojure/clojurescript/wiki/Compiler-Options#foreign-libs
 
   The second parameter cb, is a 1-arity function which receives the
@@ -939,7 +939,7 @@
 
   It initializes the repl harness either on first execution or if an
   option in #{:src-paths :init-fn!} changes from the previous
-  `read-eval-call`."
+  read-eval-call."
   [opts cb source]
   (try
     (let [expression-form (repl-read-string source)

--- a/src/cljs/replumb/repl.cljs
+++ b/src/cljs/replumb/repl.cljs
@@ -880,7 +880,9 @@
   The first parameter is a map of configuration options, currently
   supporting:
 
-  * :verbose - will enable the the evaluation logging, defaults to false
+  * :verbose - will enable the evaluation logging, defaults to false.
+  To customize how to print, use (set! *print-fn* (fn [& args] ...)
+
   * :warning-as-error - will consider a compiler warning as error
   * :target - :nodejs and :browser supported, the latter is used if
   missing


### PR DESCRIPTION
Small changes for improving the log experience with replumb, now `debug-prn` just uses `println` so that client code can customize `*print-fn*`:

```
(set! *print-fn*
    (fn [& args]
      (.apply (.-debug js/console) js/console (into-array args))))
```

The browser-repl demo now reflects that.
