### PR TITLE
Fix single letter namespaces in tests

### DIFF
--- a/src/cljs/replumb/repl.cljs
+++ b/src/cljs/replumb/repl.cljs
@@ -850,7 +850,7 @@
   Data is passed from outside and will be forwarded to :init-fn!."
   [opts data]
   (when (:verbose opts)
-    (common/debug-prn "Initializing REPL environment with data" (println data)))
+    (common/debug-prn "Initializing REPL environment with data" (with-out-str (pprint data))))
 
   ;; Target/user init, we need at least one init-fn, the default init function
   (let [init-fns (:init-fns opts)]

--- a/test/cljs/replumb/repl_test.cljs
+++ b/test/cljs/replumb/repl_test.cljs
@@ -392,11 +392,9 @@ select-keys
       (reset-env!)))
 
   (deftest macros
-;;;;;;;;;;;;;;;;
     ;; Implementing examples from Mike Fikes work at:
     ;; http://blog.fikesfarm.com/posts/2015-09-07-messing-with-macros-at-the-repl.html
     ;; (it's not that I don't trust Mike, you know)
-;;;;;;;;;;;;;;;;
     (let [res (read-eval-call "(defmacro hello [x] `(inc ~x))")
           out (unwrap-result res)]
       (is (success? res) "(defmacro hello ..) should succeed")


### PR DESCRIPTION
The tests with `:optimizations :simple` are failing because of this. This change actually discovered a
bug (#152), but it is just present with `:optimizations :simple` so we turn a blind eye to it for now.

<s>This PR was also supposed to quickly bump `tools.reader 1.0.0-alpha3` but it seems there are problems with the test.</s> (now in another PR)
