### PR TITLE
Fix compiler :optimizations :simple in Node.Js

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -159,7 +159,7 @@
             "test-slimer*" ^{:doc "Clean and execute once unit tests with SlimerJS (must be installed)."} ["do" "clean" ["doo" "slimer" "browser-test" "once"]]
             "auto-slimer" ^{:doc "Clean and execute automatic unit tests with SlimerJS (must be installed)."} ["do" "clean" ["doo" "slimer" "browser-test" "auto"]]
             "test-node" ^{:doc "Execute once unit tests with Node.js (must be installed)."} ["doo" "node" "node-test" "once"]
-            "test-node*" ^{:doc "Clean and execute once unit tests with Node.js (must be installed)."} ["do" "clean" ["doo" "node" "node-test" "once"]]
+            "test-node-simple" ^{:doc "Clean and execute once unit tests with Node.js (must be installed)."} ["doo" "node" "node-test-simple" "once"]
             "auto-node" ^{:doc "Clean and execute automatic unit tests with Node.js (must be installed)."} ["do" "clean" ["doo" "node" "node-test" "auto"]]
             "tests" ^{:doc "Execute once unit tests with PhantomJS and SlimerJS (must be installed)."} ["doo" "headless" "browser-test" "once"]
             "tests*" ^{:doc "Clean and execute once unit tests with PhantomJS and SlimerJS (must be installed)."} ["do" "clean" ["doo" "headless" "browser-test" "once"]]}

--- a/project.clj
+++ b/project.clj
@@ -15,6 +15,7 @@
                                     "dev-resources/private/browser/js/compiled" ;; browser-repl
                                     "dev-resources/private/browser/js/simple/compiled" ;; browser-repl-simple
                                     "dev-resources/private/node/js/compiled" ;; node-repl
+                                    "dev-resources/private/node/js/simple/compiled" ;; node-repl-simple
                                     "dev-resources/private/test/browser/compiled" ;; browser-test, browser-simple-test
                                     "dev-resources/private/test/node/compiled" ;; node-test, node-simple-test
                                     "dev-resources/public/js/compiled" ;; min
@@ -63,6 +64,17 @@
                                    :output-to "dev-resources/private/node/js/compiled/nodejs-repl.js"
                                    :output-dir "dev-resources/private/node/js/compiled/out"
                                    :asset-path "dev-resources/private/node/js/compiled/out"
+                                   :static-fns true
+                                   :parallel-build true}}
+                       {:id "node-repl-simple"
+                        :source-paths ["src/cljs" "src/node" "repl-demo/node/cljs"]
+                        :compiler {:target :nodejs
+                                   :optimizations :simple
+                                   :main nodejs-repl.core
+                                   :output-to "dev-resources/private/node/js/simple/compiled/nodejs-repl.js"
+                                   :output-dir "dev-resources/private/node/js/simple/compiled/out"
+                                   :asset-path "js/simple/compiled/out"
+                                   :source-map "dev-resources/private/node/js/simple/compiled/replumb-repl.js.map"
                                    :static-fns true
                                    :parallel-build true}}
                        {:id "browser-test"
@@ -133,6 +145,7 @@
             "fig-dev*" ^{:doc "Clean and start figwheel with dev profile"} ["do" "clean" ["figwheel" "dev"]]
 
             "node-repl" ^{:doc "Clean, build and launch the node demo repl. Node.js must be installed."} ["do" "clean" ["cljsbuild" "once" "node-repl"] ["shell" "scripts/node-repl.sh"]]
+            "node-repl-simple" ^{:doc "Clean, build and launch the node demo repl. Node.js must be installed."} ["do" "clean" ["cljsbuild" "once" "node-repl-simple"] ["shell" "scripts/node-repl.sh" "--simple"]]
             "browser-repl" ^{:doc "Clean, build and launch the browser demo repl."} ["do" "clean" ["cljsbuild" "once" "browser-repl"] ["shell" "scripts/browser-repl.sh"]]
             "browser-repl-simple" ^{:doc "Clean, build and launch the browser demo repl."} ["do" "clean" ["cljsbuild" "once" "browser-repl-simple"] ["shell" "scripts/browser-repl.sh"]]
 

--- a/scripts/node-repl.sh
+++ b/scripts/node-repl.sh
@@ -1,5 +1,17 @@
 #!/bin/bash
 
+JS=dev-resources/private/node/js/compiled/nodejs-repl.js
+VERBOSE=
+
+if [ "$1" == "--simple" ]; then
+    JS=dev-resources/private/node/js/simple/compiled/nodejs-repl.js
+fi
+
+if [[ "$1" == "--verbose" ]] || [[ $2 == "--verbose" ]]
+then
+    VERBOSE=--verbose
+fi
+
 # For convenience you can pass --verbose here and it will be forwarded to the repl
-node dev-resources/private/node/js/compiled/nodejs-repl.js $1 \
+node $JS $VERBOSE \
      dev-resources/private/node/js/compiled/out:dev-resources/private/test/src/cljs:dev-resources/private/test/src/clj:dev-resources/private/test/src/cljc:dev-resources/private/test/src/js

--- a/src/cljs/replumb/browser.cljs
+++ b/src/cljs/replumb/browser.cljs
@@ -1,8 +1,9 @@
-(ns replumb.browser)
+(ns replumb.browser
+  (:require [replumb.common :as common]))
 
 (defn init-fn!
   []
-  (set! (.. js/window -cljs -user) #js {})
+  (common/set-cljs-user! js/window)
   ;; AR - mimicking clojurescript/src/main/cljs/clojure/browser/repl.cljs
   (set! (.-require__ js/goog) js/goog.require)
   ;; repl.cljs - suppress useless Google Closure error about duplicate provides

--- a/src/cljs/replumb/common.cljs
+++ b/src/cljs/replumb/common.cljs
@@ -121,3 +121,8 @@
   "Adds a / if missing at the end of the path."
   [path]
   (str path (when-not (= "/" (last path)) "/")))
+
+(defn set-cljs-user!
+  "Set up the cljs.user namespace on the input object"
+  [object]
+  (set! (.-user js/cljs) #js {}))

--- a/src/cljs/replumb/nodejs.cljs
+++ b/src/cljs/replumb/nodejs.cljs
@@ -1,8 +1,9 @@
-(ns replumb.nodejs)
+(ns replumb.nodejs
+  (:require [replumb.common :as common]))
 
 (defn init-fn!
   []
-  (set! (.. js/global -cljs -user) #js {})
+  (common/set-cljs-user! js/global)
   ;; AR - mimicking clojurescript/src/main/clojure/cljs/repl/node.clj
   ;; This solves https://github.com/ScalaConsultants/replumb/issues/56
   ;; node.clj - monkey-patch goog.require, skip all the loaded checks


### PR DESCRIPTION
This fixes `:simple` problems. The test all pass except `replumb.cache-test`.
Note that for `lein test-node-simple` you need to manually copy the dependency collected with `replumb.boot-pack-source` as of course `:simple` omits a lot of stuff from `out`.

It's about time we move this project to `boot` as well.
