### PR TITLE
Remove the auto init feature

### DIFF
--- a/src/cljs/replumb/core.cljs
+++ b/src/cljs/replumb/core.cljs
@@ -237,5 +237,4 @@
   (repl/read-eval-call opts identity "(in-ns 'cljs.user)")
   ;; Other side effects
   (repl/reset-last-warning!)
-  (repl/read-eval-call opts identity "(set! *e nil)")
-  (repl/reset-init-opts!))
+  (repl/read-eval-call opts identity "(set! *e nil)"))


### PR DESCRIPTION
This feature was introduced mainly for handling the test abundant error but it has never been
useful. We shred it happily.
