### PR TITLE
Exclude resolve to avoid warning on compile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ before_script:
     - cd scripts; curl -O https://raw.githubusercontent.com/technomancy/leiningen/stable/bin/lein; chmod +x lein; cd ..
     - scripts/lein version
     - phantomjs -v
-    - nvm use 0.12.7
+    - nvm install 0.12.7
     - node -v
 script: scripts/lein tests
 jdk:

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject replumb/replumb "0.2.4"
+(defproject replumb/replumb "0.2.5-SNAPSHOT"
   :description "ClojureScript plumbing for your bootstrapped REPLs."
   :url "https://github.com/Lambda-X/replumb"
   :license {:name "Eclipse Public License"

--- a/src/cljs/replumb/repl.cljs
+++ b/src/cljs/replumb/repl.cljs
@@ -1,5 +1,5 @@
 (ns replumb.repl
-  (:refer-clojure :exclude [load-file ns-publics ns-interns find-ns])
+  (:refer-clojure :exclude [load-file ns-publics ns-interns find-ns resolve])
   (:require-macros [cljs.env.macros :refer [with-compiler-env]])
   (:require [cljs.js :as cljs]
             [cljs.tagged-literals :as tags]


### PR DESCRIPTION
Minor change to avoid a compiler warning when using replumb